### PR TITLE
Update component search request param default value

### DIFF
--- a/protobuf/scanoss/api/components/v2/scanoss-components.proto
+++ b/protobuf/scanoss/api/components/v2/scanoss-components.proto
@@ -160,7 +160,7 @@ message CompSearchResponse {
 message CompVersionRequest {
   // Component to search for (purl)
   string purl = 1;
-  // Number of versions to return - default 20
+  // Number of versions to return - default 50
   int32 limit = 2;
 }
 


### PR DESCRIPTION
## Why
- Default is set to 50 in components service ([here](https://github.com/scanoss/components/blob/691ff3b885628047b036b9675ff9d1a9983ef67d/pkg/models/components.go#L28))