### PR TITLE
Deprecating PurlRequest in favor of PurlQueryRequest

### DIFF
--- a/protobuf/scanoss/api/common/v2/scanoss-common.proto
+++ b/protobuf/scanoss/api/common/v2/scanoss-common.proto
@@ -66,6 +66,7 @@ message EchoResponse {
 }
 
 /*
+ * WARNING: PurlRequest is deprecated, use PurlQueryRequest instead.
  * Purl request data (JSON payload)
  */
 message PurlRequest {
@@ -88,5 +89,23 @@ message PurlRequest {
  */
 message Purl {
   string purl = 1;
+  string requirement = 2;
+}
+
+/*
+ * Request containing PURL queries for batch operations
+ */
+message PurlQueryRequest {
+  // List of component queries to process
+  repeated PurlQuery queries = 1;
+}
+
+/*
+ * Query specification for a component using PURL (Package URL)
+ */
+message PurlQuery {
+  // Package URL (PURL) identifying the component (e.g., "pkg:npm/express@4.0.0")
+  string purl = 1;
+  // Optional version requirement or constraint (e.g., "^1.0.0", ">=2.0.0", "<3.0.0")
   string requirement = 2;
 }


### PR DESCRIPTION
##  Deprecating PurlRequest in favor of PurlQueryRequest 
This PR deprecates `PurlRequest` and introduces `PurlQueryRequest` as the new standard for querying components by PURL across all services.

### WHY

1. The previous implementation suffered from awkward field access patterns (`purl.purl`) due to naming redundancy
2. The new structure provides clearer, more intuitive access (`query.purl`)
