### PR TITLE
Chore/refactor geo provenance protobuf definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+## [0.23.0] - 2025-09-22
+### Added
+- Added gRPC `GetCountryContributorsByComponents` and REST endpoint POST `/v2/geoprovenance/countries/components`
+- Added gRPC `GetCountryContributorsByComponent` and REST endpoint GET `/v2/geoprovenance/countries/component`
+- Added gRPC `GetOriginByComponents` and REST endpoint POST `/v2/geoprovenance/origin/components`
+- Added gRPC `GetOriginByComponent` and REST endpoint GET `/v2/geoprovenance/origin/component`
+- Added comprehensive documentation to geo-provenance protobuf service
+- Added geo-provenance API documentation (README.md)
+- Added JSON schema examples to geo-provenance response messages
+- Added new response message types `ComponentsContributorResponse` and `ComponentsOriginResponse` for enhanced component handling
+### Changed
+- Enhanced geo-provenance protobuf definitions with comprehensive service and message documentation
+- Updated OpenAPI schema with realistic JSON response examples for geo-provenance endpoints
+- Enhanced field documentation across all geo-provenance message types
+### Deprecated
+- Deprecated gRPC `GetComponentContributors` method (use `GetCountryContributorsByComponents` instead)
+- Deprecated gRPC `GetComponentOrigin` method (use `GetOriginByComponents` instead)
+- Deprecated `ContributorResponse` and `OriginResponse` message types (use new component-based response types instead)
+
+## [0.22.0] - 2025-09-22
+
 ## [0.21.0] - 2025-09-18
 ### Added
 - Added README.md documentation for Components Service API v2
@@ -156,8 +177,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added REST endpoint support for each service also
 
 [Unreleased]: https://github.com/scanoss/papi/compare/v0.12.0...HEAD
+[0.23.0]: https://github.com/scanoss/papi/compare/v0.22.0...v0.23.0
+[0.22.0]: https://github.com/scanoss/papi/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/scanoss/papi/compare/v0.20.1...v0.21.0
-[0.21.1]: https://github.com/scanoss/papi/compare/v0.20.0...v0.20.1
+[0.20.1]: https://github.com/scanoss/papi/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/scanoss/papi/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/scanoss/papi/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/scanoss/papi/compare/v0.17.0...v0.18.0

--- a/api/geoprovenancev2/scanoss-geoprovenance.pb.go
+++ b/api/geoprovenancev2/scanoss-geoprovenance.pb.go
@@ -50,13 +50,127 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Declared location information for the project
+type DeclaredLocation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Source type of the declared location (e.g., "owner" or "contributor")
+	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	// Geographic location declared in the repository (Country/State/City/Province/Place)
+	Location      string `protobuf:"bytes,2,opt,name=location,proto3" json:"location,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeclaredLocation) Reset() {
+	*x = DeclaredLocation{}
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeclaredLocation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeclaredLocation) ProtoMessage() {}
+
+func (x *DeclaredLocation) ProtoReflect() protoreflect.Message {
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeclaredLocation.ProtoReflect.Descriptor instead.
+func (*DeclaredLocation) Descriptor() ([]byte, []int) {
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *DeclaredLocation) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *DeclaredLocation) GetLocation() string {
+	if x != nil {
+		return x.Location
+	}
+	return ""
+}
+
+// SCANOSS curated provenance information about the project
+type CuratedLocation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Country name for the owner or contributor
+	Country string `protobuf:"bytes,1,opt,name=country,proto3" json:"country,omitempty"`
+	// Number of users or contributors from this specific country
+	Count         int32 `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CuratedLocation) Reset() {
+	*x = CuratedLocation{}
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CuratedLocation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CuratedLocation) ProtoMessage() {}
+
+func (x *CuratedLocation) ProtoReflect() protoreflect.Message {
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CuratedLocation.ProtoReflect.Descriptor instead.
+func (*CuratedLocation) Descriptor() ([]byte, []int) {
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *CuratedLocation) GetCountry() string {
+	if x != nil {
+		return x.Country
+	}
+	return ""
+}
+
+func (x *CuratedLocation) GetCount() int32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
 // *
-// Component level Provenance Response data (JSON payload)
+// [DEPRECATED] Component level Provenance Response data (JSON payload)
+// This message is deprecated. Use ComponentContributorResponse instead for better component handling.
+// Contains geo-provenance information for components based on contributor declared locations.
+//
+// Deprecated: Marked as deprecated in scanoss/api/geoprovenance/v2/scanoss-geoprovenance.proto.
 type ContributorResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Provenance details
+	// Geo-provenance details for each requested component
 	Purls []*ContributorResponse_Purls `protobuf:"bytes,1,rep,name=purls,proto3" json:"purls,omitempty"`
-	// Response status
+	// Response status indicating success or failure of the request
 	Status        *commonv2.StatusResponse `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -64,7 +178,7 @@ type ContributorResponse struct {
 
 func (x *ContributorResponse) Reset() {
 	*x = ContributorResponse{}
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[0]
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -76,7 +190,7 @@ func (x *ContributorResponse) String() string {
 func (*ContributorResponse) ProtoMessage() {}
 
 func (x *ContributorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[0]
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -89,7 +203,7 @@ func (x *ContributorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContributorResponse.ProtoReflect.Descriptor instead.
 func (*ContributorResponse) Descriptor() ([]byte, []int) {
-	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{0}
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *ContributorResponse) GetPurls() []*ContributorResponse_Purls {
@@ -106,13 +220,307 @@ func (x *ContributorResponse) GetStatus() *commonv2.StatusResponse {
 	return nil
 }
 
+// Information about a given component
+type ComponentLocationInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The Package URL string identifying the component
+	Purl string `protobuf:"bytes,1,opt,name=purl,proto3" json:"purl,omitempty"`
+	// List of locations declared in the component's repository
+	DeclaredLocations []*DeclaredLocation `protobuf:"bytes,2,rep,name=declared_locations,proto3" json:"declared_locations,omitempty"`
+	// List of SCANOSS curated locations based on analysis
+	CuratedLocations []*CuratedLocation `protobuf:"bytes,3,rep,name=curated_locations,proto3" json:"curated_locations,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ComponentLocationInfo) Reset() {
+	*x = ComponentLocationInfo{}
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ComponentLocationInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ComponentLocationInfo) ProtoMessage() {}
+
+func (x *ComponentLocationInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ComponentLocationInfo.ProtoReflect.Descriptor instead.
+func (*ComponentLocationInfo) Descriptor() ([]byte, []int) {
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ComponentLocationInfo) GetPurl() string {
+	if x != nil {
+		return x.Purl
+	}
+	return ""
+}
+
+func (x *ComponentLocationInfo) GetDeclaredLocations() []*DeclaredLocation {
+	if x != nil {
+		return x.DeclaredLocations
+	}
+	return nil
+}
+
+func (x *ComponentLocationInfo) GetCuratedLocations() []*CuratedLocation {
+	if x != nil {
+		return x.CuratedLocations
+	}
+	return nil
+}
+
 // *
-// Component level Origin Response data (JSON payload)
+// Component level Provenance Response data (JSON payload)
+// Contains geo-provenance information for components based on contributor declared locations.
+// This is the current response format that replaces the deprecated ContributorResponse.
+type ComponentsContributorResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Geo-provenance details for each requested component
+	ComponentsLocations []*ComponentLocationInfo `protobuf:"bytes,1,rep,name=components_locations,proto3" json:"components_locations,omitempty"`
+	// Response status indicating success or failure of the request
+	Status        *commonv2.StatusResponse `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ComponentsContributorResponse) Reset() {
+	*x = ComponentsContributorResponse{}
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ComponentsContributorResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ComponentsContributorResponse) ProtoMessage() {}
+
+func (x *ComponentsContributorResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ComponentsContributorResponse.ProtoReflect.Descriptor instead.
+func (*ComponentsContributorResponse) Descriptor() ([]byte, []int) {
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ComponentsContributorResponse) GetComponentsLocations() []*ComponentLocationInfo {
+	if x != nil {
+		return x.ComponentsLocations
+	}
+	return nil
+}
+
+func (x *ComponentsContributorResponse) GetStatus() *commonv2.StatusResponse {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+// *
+// Component level Provenance Response data (JSON payload)
+// Contains geo-provenance information for components based on contributor declared locations.
+// This is the current response format that replaces the deprecated ContributorResponse.
+type ComponentContributorResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Geo-provenance details for each requested component
+	ComponentLocations *ComponentLocationInfo `protobuf:"bytes,1,opt,name=component_locations,proto3" json:"component_locations,omitempty"`
+	// Response status indicating success or failure of the request
+	Status        *commonv2.StatusResponse `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ComponentContributorResponse) Reset() {
+	*x = ComponentContributorResponse{}
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ComponentContributorResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ComponentContributorResponse) ProtoMessage() {}
+
+func (x *ComponentContributorResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ComponentContributorResponse.ProtoReflect.Descriptor instead.
+func (*ComponentContributorResponse) Descriptor() ([]byte, []int) {
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ComponentContributorResponse) GetComponentLocations() *ComponentLocationInfo {
+	if x != nil {
+		return x.ComponentLocations
+	}
+	return nil
+}
+
+func (x *ComponentContributorResponse) GetStatus() *commonv2.StatusResponse {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+// Origin country details for geo-provenance analysis
+type Location struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ISO country code (e.g., "US", "GB", "FR")
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Percentage of developers from this country
+	Percentage    float32 `protobuf:"fixed32,2,opt,name=percentage,proto3" json:"percentage,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Location) Reset() {
+	*x = Location{}
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Location) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Location) ProtoMessage() {}
+
+func (x *Location) ProtoReflect() protoreflect.Message {
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Location.ProtoReflect.Descriptor instead.
+func (*Location) Descriptor() ([]byte, []int) {
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *Location) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Location) GetPercentage() float32 {
+	if x != nil {
+		return x.Percentage
+	}
+	return 0
+}
+
+// Information about a component and its geographic origins
+type ComponentLocation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The Package URL string identifying the component
+	Purl string `protobuf:"bytes,1,opt,name=purl,proto3" json:"purl,omitempty"`
+	// The list of countries with contributors and their percentages
+	Locations     []*Location `protobuf:"bytes,2,rep,name=locations,proto3" json:"locations,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ComponentLocation) Reset() {
+	*x = ComponentLocation{}
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ComponentLocation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ComponentLocation) ProtoMessage() {}
+
+func (x *ComponentLocation) ProtoReflect() protoreflect.Message {
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ComponentLocation.ProtoReflect.Descriptor instead.
+func (*ComponentLocation) Descriptor() ([]byte, []int) {
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ComponentLocation) GetPurl() string {
+	if x != nil {
+		return x.Purl
+	}
+	return ""
+}
+
+func (x *ComponentLocation) GetLocations() []*Location {
+	if x != nil {
+		return x.Locations
+	}
+	return nil
+}
+
+// *
+// [DEPRECATED] Component level Origin Response data (JSON payload)
+// This message is deprecated. Use ComponentOriginResponse instead for better component handling.
+// Contains geo-provenance information based on contributor origin commit times.
+//
+// Deprecated: Marked as deprecated in scanoss/api/geoprovenance/v2/scanoss-geoprovenance.proto.
 type OriginResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Geo Provenance details
+	// Geo-provenance details for each requested component
 	Purls []*OriginResponse_Purls `protobuf:"bytes,1,rep,name=purls,proto3" json:"purls,omitempty"`
-	// Response status
+	// Response status indicating success or failure of the request
 	Status        *commonv2.StatusResponse `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -120,7 +528,7 @@ type OriginResponse struct {
 
 func (x *OriginResponse) Reset() {
 	*x = OriginResponse{}
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[1]
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -132,7 +540,7 @@ func (x *OriginResponse) String() string {
 func (*OriginResponse) ProtoMessage() {}
 
 func (x *OriginResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[1]
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -145,7 +553,7 @@ func (x *OriginResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OriginResponse.ProtoReflect.Descriptor instead.
 func (*OriginResponse) Descriptor() ([]byte, []int) {
-	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{1}
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *OriginResponse) GetPurls() []*OriginResponse_Purls {
@@ -162,32 +570,36 @@ func (x *OriginResponse) GetStatus() *commonv2.StatusResponse {
 	return nil
 }
 
-// Declared location for the project
-type ContributorResponse_DeclaredLocation struct {
+// *
+// Component level Origin Response data (JSON payload)
+// Contains geo-provenance information based on contributor origin commit times.
+// This is the current response format that replaces the deprecated OriginResponse.
+// Provides enhanced component identification and location data.
+type ComponentsOriginResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Declared location could be either from the owner or a contributor
-	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
-	// Country/State/City/Province/Place declared on the repo
-	Location      string `protobuf:"bytes,2,opt,name=location,proto3" json:"location,omitempty"`
+	// Geo-provenance details for each requested component
+	ComponentsLocations []*ComponentLocation `protobuf:"bytes,1,rep,name=components_locations,proto3" json:"components_locations,omitempty"`
+	// Response status indicating success or failure of the request
+	Status        *commonv2.StatusResponse `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ContributorResponse_DeclaredLocation) Reset() {
-	*x = ContributorResponse_DeclaredLocation{}
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[2]
+func (x *ComponentsOriginResponse) Reset() {
+	*x = ComponentsOriginResponse{}
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ContributorResponse_DeclaredLocation) String() string {
+func (x *ComponentsOriginResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ContributorResponse_DeclaredLocation) ProtoMessage() {}
+func (*ComponentsOriginResponse) ProtoMessage() {}
 
-func (x *ContributorResponse_DeclaredLocation) ProtoReflect() protoreflect.Message {
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[2]
+func (x *ComponentsOriginResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -198,51 +610,55 @@ func (x *ContributorResponse_DeclaredLocation) ProtoReflect() protoreflect.Messa
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ContributorResponse_DeclaredLocation.ProtoReflect.Descriptor instead.
-func (*ContributorResponse_DeclaredLocation) Descriptor() ([]byte, []int) {
-	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{0, 0}
+// Deprecated: Use ComponentsOriginResponse.ProtoReflect.Descriptor instead.
+func (*ComponentsOriginResponse) Descriptor() ([]byte, []int) {
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{9}
 }
 
-func (x *ContributorResponse_DeclaredLocation) GetType() string {
+func (x *ComponentsOriginResponse) GetComponentsLocations() []*ComponentLocation {
 	if x != nil {
-		return x.Type
+		return x.ComponentsLocations
 	}
-	return ""
+	return nil
 }
 
-func (x *ContributorResponse_DeclaredLocation) GetLocation() string {
+func (x *ComponentsOriginResponse) GetStatus() *commonv2.StatusResponse {
 	if x != nil {
-		return x.Location
+		return x.Status
 	}
-	return ""
+	return nil
 }
 
-// Curated provenance information about the project
-type ContributorResponse_CuratedLocation struct {
+// *
+// Component level Origin Response data (JSON payload)
+// Contains geo-provenance information based on contributor origin commit times.
+// This is the current response format that replaces the deprecated OriginResponse.
+// Provides enhanced component identification and location data.
+type ComponentOriginResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Country for the owner or contributor
-	Country string `protobuf:"bytes,1,opt,name=country,proto3" json:"country,omitempty"`
-	// Occurrences for users or contributors of this specific country
-	Count         int32 `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`
+	// Geo-provenance details for each requested component
+	ComponentLocations *ComponentLocation `protobuf:"bytes,1,opt,name=component_locations,proto3" json:"component_locations,omitempty"`
+	// Response status indicating success or failure of the request
+	Status        *commonv2.StatusResponse `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ContributorResponse_CuratedLocation) Reset() {
-	*x = ContributorResponse_CuratedLocation{}
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[3]
+func (x *ComponentOriginResponse) Reset() {
+	*x = ComponentOriginResponse{}
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ContributorResponse_CuratedLocation) String() string {
+func (x *ComponentOriginResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ContributorResponse_CuratedLocation) ProtoMessage() {}
+func (*ComponentOriginResponse) ProtoMessage() {}
 
-func (x *ContributorResponse_CuratedLocation) ProtoReflect() protoreflect.Message {
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[3]
+func (x *ComponentOriginResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -253,41 +669,41 @@ func (x *ContributorResponse_CuratedLocation) ProtoReflect() protoreflect.Messag
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ContributorResponse_CuratedLocation.ProtoReflect.Descriptor instead.
-func (*ContributorResponse_CuratedLocation) Descriptor() ([]byte, []int) {
-	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{0, 1}
+// Deprecated: Use ComponentOriginResponse.ProtoReflect.Descriptor instead.
+func (*ComponentOriginResponse) Descriptor() ([]byte, []int) {
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{10}
 }
 
-func (x *ContributorResponse_CuratedLocation) GetCountry() string {
+func (x *ComponentOriginResponse) GetComponentLocations() *ComponentLocation {
 	if x != nil {
-		return x.Country
+		return x.ComponentLocations
 	}
-	return ""
+	return nil
 }
 
-func (x *ContributorResponse_CuratedLocation) GetCount() int32 {
+func (x *ComponentOriginResponse) GetStatus() *commonv2.StatusResponse {
 	if x != nil {
-		return x.Count
+		return x.Status
 	}
-	return 0
+	return nil
 }
 
-// Information about a given purl
+// Information about a given Package URL (PURL)
 type ContributorResponse_Purls struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The purl string
+	// The Package URL string identifying the component
 	Purl string `protobuf:"bytes,1,opt,name=purl,proto3" json:"purl,omitempty"`
-	// List of locations declared on user repository
-	DeclaredLocations []*ContributorResponse_DeclaredLocation `protobuf:"bytes,2,rep,name=declared_locations,json=declaredLocations,proto3" json:"declared_locations,omitempty"`
-	// List of craft curated location
-	CuratedLocations []*ContributorResponse_CuratedLocation `protobuf:"bytes,3,rep,name=curated_locations,json=curatedLocations,proto3" json:"curated_locations,omitempty"`
+	// List of locations declared in the component's repository
+	DeclaredLocations []*DeclaredLocation `protobuf:"bytes,2,rep,name=declared_locations,proto3" json:"declared_locations,omitempty"`
+	// List of SCANOSS curated locations based on analysis
+	CuratedLocations []*CuratedLocation `protobuf:"bytes,3,rep,name=curated_locations,proto3" json:"curated_locations,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ContributorResponse_Purls) Reset() {
 	*x = ContributorResponse_Purls{}
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[4]
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -299,7 +715,7 @@ func (x *ContributorResponse_Purls) String() string {
 func (*ContributorResponse_Purls) ProtoMessage() {}
 
 func (x *ContributorResponse_Purls) ProtoReflect() protoreflect.Message {
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[4]
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -312,7 +728,7 @@ func (x *ContributorResponse_Purls) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContributorResponse_Purls.ProtoReflect.Descriptor instead.
 func (*ContributorResponse_Purls) Descriptor() ([]byte, []int) {
-	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{0, 2}
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{2, 0}
 }
 
 func (x *ContributorResponse_Purls) GetPurl() string {
@@ -322,89 +738,35 @@ func (x *ContributorResponse_Purls) GetPurl() string {
 	return ""
 }
 
-func (x *ContributorResponse_Purls) GetDeclaredLocations() []*ContributorResponse_DeclaredLocation {
+func (x *ContributorResponse_Purls) GetDeclaredLocations() []*DeclaredLocation {
 	if x != nil {
 		return x.DeclaredLocations
 	}
 	return nil
 }
 
-func (x *ContributorResponse_Purls) GetCuratedLocations() []*ContributorResponse_CuratedLocation {
+func (x *ContributorResponse_Purls) GetCuratedLocations() []*CuratedLocation {
 	if x != nil {
 		return x.CuratedLocations
 	}
 	return nil
 }
 
-// Origin country details
-type OriginResponse_Location struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// ISO Country code
-	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Percentage of developers
-	Percentage    float32 `protobuf:"fixed32,2,opt,name=percentage,proto3" json:"percentage,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *OriginResponse_Location) Reset() {
-	*x = OriginResponse_Location{}
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[5]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *OriginResponse_Location) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*OriginResponse_Location) ProtoMessage() {}
-
-func (x *OriginResponse_Location) ProtoReflect() protoreflect.Message {
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[5]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use OriginResponse_Location.ProtoReflect.Descriptor instead.
-func (*OriginResponse_Location) Descriptor() ([]byte, []int) {
-	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{1, 0}
-}
-
-func (x *OriginResponse_Location) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
-func (x *OriginResponse_Location) GetPercentage() float32 {
-	if x != nil {
-		return x.Percentage
-	}
-	return 0
-}
-
-// Information about the given PURL
+// Origin country details for geo-provenance analysis
+// Information about the given Package URL (PURL)
 type OriginResponse_Purls struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The purl string
+	// The Package URL string identifying the component
 	Purl string `protobuf:"bytes,1,opt,name=purl,proto3" json:"purl,omitempty"`
-	// The list of countries with contributors
-	Locations     []*OriginResponse_Location `protobuf:"bytes,2,rep,name=locations,proto3" json:"locations,omitempty"`
+	// The list of countries with contributors and their percentages
+	Locations     []*Location `protobuf:"bytes,2,rep,name=locations,proto3" json:"locations,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *OriginResponse_Purls) Reset() {
 	*x = OriginResponse_Purls{}
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[6]
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -416,7 +778,7 @@ func (x *OriginResponse_Purls) String() string {
 func (*OriginResponse_Purls) ProtoMessage() {}
 
 func (x *OriginResponse_Purls) ProtoReflect() protoreflect.Message {
-	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[6]
+	mi := &file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -429,7 +791,7 @@ func (x *OriginResponse_Purls) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OriginResponse_Purls.ProtoReflect.Descriptor instead.
 func (*OriginResponse_Purls) Descriptor() ([]byte, []int) {
-	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{1, 1}
+	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP(), []int{8, 0}
 }
 
 func (x *OriginResponse_Purls) GetPurl() string {
@@ -439,7 +801,7 @@ func (x *OriginResponse_Purls) GetPurl() string {
 	return ""
 }
 
-func (x *OriginResponse_Purls) GetLocations() []*OriginResponse_Location {
+func (x *OriginResponse_Purls) GetLocations() []*Location {
 	if x != nil {
 		return x.Locations
 	}
@@ -450,35 +812,62 @@ var File_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto protoreflect.F
 
 const file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDesc = "" +
 	"\n" +
-	"8scanoss/api/geoprovenance/v2/scanoss-geoprovenance.proto\x12\x1cscanoss.api.geoprovenance.v2\x1a*scanoss/api/common/v2/scanoss-common.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\xab\x04\n" +
-	"\x13ContributorResponse\x12M\n" +
-	"\x05purls\x18\x01 \x03(\v27.scanoss.api.geoprovenance.v2.ContributorResponse.PurlsR\x05purls\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1aB\n" +
+	"8scanoss/api/geoprovenance/v2/scanoss-geoprovenance.proto\x12\x1cscanoss.api.geoprovenance.v2\x1a*scanoss/api/common/v2/scanoss-common.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"B\n" +
 	"\x10DeclaredLocation\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1a\n" +
-	"\blocation\x18\x02 \x01(\tR\blocation\x1aA\n" +
+	"\blocation\x18\x02 \x01(\tR\blocation\"A\n" +
 	"\x0fCuratedLocation\x12\x18\n" +
 	"\acountry\x18\x01 \x01(\tR\acountry\x12\x14\n" +
-	"\x05count\x18\x02 \x01(\x05R\x05count\x1a\xfe\x01\n" +
+	"\x05count\x18\x02 \x01(\x05R\x05count\"\x82\x03\n" +
+	"\x13ContributorResponse\x12M\n" +
+	"\x05purls\x18\x01 \x03(\v27.scanoss.api.geoprovenance.v2.ContributorResponse.PurlsR\x05purls\x12=\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\xd8\x01\n" +
 	"\x05Purls\x12\x12\n" +
-	"\x04purl\x18\x01 \x01(\tR\x04purl\x12q\n" +
-	"\x12declared_locations\x18\x02 \x03(\v2B.scanoss.api.geoprovenance.v2.ContributorResponse.DeclaredLocationR\x11declaredLocations\x12n\n" +
-	"\x11curated_locations\x18\x03 \x03(\v2A.scanoss.api.geoprovenance.v2.ContributorResponse.CuratedLocationR\x10curatedLocations\"\xcb\x02\n" +
-	"\x0eOriginResponse\x12H\n" +
-	"\x05purls\x18\x01 \x03(\v22.scanoss.api.geoprovenance.v2.OriginResponse.PurlsR\x05purls\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a>\n" +
+	"\x04purl\x18\x01 \x01(\tR\x04purl\x12^\n" +
+	"\x12declared_locations\x18\x02 \x03(\v2..scanoss.api.geoprovenance.v2.DeclaredLocationR\x12declared_locations\x12[\n" +
+	"\x11curated_locations\x18\x03 \x03(\v2-.scanoss.api.geoprovenance.v2.CuratedLocationR\x11curated_locations:\x02\x18\x01\"\xe8\x01\n" +
+	"\x15ComponentLocationInfo\x12\x12\n" +
+	"\x04purl\x18\x01 \x01(\tR\x04purl\x12^\n" +
+	"\x12declared_locations\x18\x02 \x03(\v2..scanoss.api.geoprovenance.v2.DeclaredLocationR\x12declared_locations\x12[\n" +
+	"\x11curated_locations\x18\x03 \x03(\v2-.scanoss.api.geoprovenance.v2.CuratedLocationR\x11curated_locations\"\xdd\x04\n" +
+	"\x1dComponentsContributorResponse\x12g\n" +
+	"\x14components_locations\x18\x01 \x03(\v23.scanoss.api.geoprovenance.v2.ComponentLocationInfoR\x14components_locations\x12=\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x93\x03\x92A\x8f\x03\n" +
+	"\x8c\x03J\x89\x03{\"components_locations\":[{\"purl\":\"pkg:github/scanoss/engine@5.0.0\",\"declared_locations\":[{\"type\":\"owner\",\"location\":\"Barcelona, Spain\"},{\"type\":\"contributor\",\"location\":\"Berlin, Germany\"}],\"curated_locations\":[{\"country\":\"Spain\",\"count\":8},{\"country\":\"Germany\",\"count\":3},{\"country\":\"United States\",\"count\":2}]}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Geo-provenance successfully retrieved\"}}\"\xd6\x04\n" +
+	"\x1cComponentContributorResponse\x12e\n" +
+	"\x13component_locations\x18\x01 \x01(\v23.scanoss.api.geoprovenance.v2.ComponentLocationInfoR\x13component_locations\x12=\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x8f\x03\x92A\x8b\x03\n" +
+	"\x88\x03J\x85\x03{\"component_location\":{\"purl\":\"pkg:github/scanoss/engine@5.0.0\",\"declared_locations\":[{\"type\":\"owner\",\"location\":\"Barcelona, Spain\"},{\"type\":\"contributor\",\"location\":\"Berlin, Germany\"}],\"curated_locations\":[{\"country\":\"Spain\",\"count\":8},{\"country\":\"Germany\",\"count\":3},{\"country\":\"United States\",\"count\":2}]},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Geo-provenance successfully retrieved\"}}\">\n" +
 	"\bLocation\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1e\n" +
 	"\n" +
 	"percentage\x18\x02 \x01(\x02R\n" +
-	"percentage\x1ap\n" +
+	"percentage\"m\n" +
+	"\x11ComponentLocation\x12\x12\n" +
+	"\x04purl\x18\x01 \x01(\tR\x04purl\x12D\n" +
+	"\tlocations\x18\x02 \x03(\v2&.scanoss.api.geoprovenance.v2.LocationR\tlocations\"\x80\x02\n" +
+	"\x0eOriginResponse\x12H\n" +
+	"\x05purls\x18\x01 \x03(\v22.scanoss.api.geoprovenance.v2.OriginResponse.PurlsR\x05purls\x12=\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1aa\n" +
 	"\x05Purls\x12\x12\n" +
-	"\x04purl\x18\x01 \x01(\tR\x04purl\x12S\n" +
-	"\tlocations\x18\x02 \x03(\v25.scanoss.api.geoprovenance.v2.OriginResponse.LocationR\tlocations2\xad\x03\n" +
+	"\x04purl\x18\x01 \x01(\tR\x04purl\x12D\n" +
+	"\tlocations\x18\x02 \x03(\v2&.scanoss.api.geoprovenance.v2.LocationR\tlocations:\x02\x18\x01\"\xd5\x03\n" +
+	"\x18ComponentsOriginResponse\x12c\n" +
+	"\x14components_locations\x18\x01 \x03(\v2/.scanoss.api.geoprovenance.v2.ComponentLocationR\x14components_locations\x12=\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x94\x02\x92A\x90\x02\n" +
+	"\x8d\x02J\x8a\x02{\"components_locations\":[{\"purl\":\"pkg:github/scanoss/engine@5.0.0\",\"locations\":[{\"name\":\"ES\",\"percentage\":65.5},{\"name\":\"DE\",\"percentage\":20.3},{\"name\":\"US\",\"percentage\":14.2}]}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Geo-provenance origin successfully retrieved\"}}\"\xd0\x03\n" +
+	"\x17ComponentOriginResponse\x12a\n" +
+	"\x13component_locations\x18\x01 \x01(\v2/.scanoss.api.geoprovenance.v2.ComponentLocationR\x13component_locations\x12=\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x92\x02\x92A\x8e\x02\n" +
+	"\x8b\x02J\x88\x02{\"component_locations\": {\"purl\":\"pkg:github/scanoss/engine@5.0.0\",\"locations\":[{\"name\":\"ES\",\"percentage\":65.5},{\"name\":\"DE\",\"percentage\":20.3},{\"name\":\"US\",\"percentage\":14.2}]},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Geo-provenance origin successfully retrieved\"}}2\xff\b\n" +
 	"\rGeoProvenance\x12r\n" +
-	"\x04Echo\x12\".scanoss.api.common.v2.EchoRequest\x1a#.scanoss.api.common.v2.EchoResponse\"!\x82\xd3\xe4\x93\x02\x1b:\x01*\"\x16/v2/geoprovenance/echo\x12\x99\x01\n" +
-	"\x18GetComponentContributors\x12\".scanoss.api.common.v2.PurlRequest\x1a1.scanoss.api.geoprovenance.v2.ContributorResponse\"&\x82\xd3\xe4\x93\x02 :\x01*\"\x1b/v2/geoprovenance/countries\x12\x8b\x01\n" +
-	"\x12GetComponentOrigin\x12\".scanoss.api.common.v2.PurlRequest\x1a,.scanoss.api.geoprovenance.v2.OriginResponse\"#\x82\xd3\xe4\x93\x02\x1d:\x01*\"\x18/v2/geoprovenance/originB\xa4\x02\x92A\xe3\x01\x12}\n" +
+	"\x04Echo\x12\".scanoss.api.common.v2.EchoRequest\x1a#.scanoss.api.common.v2.EchoResponse\"!\x82\xd3\xe4\x93\x02\x1b:\x01*\"\x16/v2/geoprovenance/echo\x12\x9c\x01\n" +
+	"\x18GetComponentContributors\x12\".scanoss.api.common.v2.PurlRequest\x1a1.scanoss.api.geoprovenance.v2.ContributorResponse\")\x82\xd3\xe4\x93\x02 :\x01*\"\x1b/v2/geoprovenance/countries\x88\x02\x01\x12\xbe\x01\n" +
+	"\"GetCountryContributorsByComponents\x12(.scanoss.api.common.v2.ComponentsRequest\x1a;.scanoss.api.geoprovenance.v2.ComponentsContributorResponse\"1\x82\xd3\xe4\x93\x02+:\x01*\"&/v2/geoprovenance/countries/components\x12\xb7\x01\n" +
+	"!GetCountryContributorsByComponent\x12'.scanoss.api.common.v2.ComponentRequest\x1a:.scanoss.api.geoprovenance.v2.ComponentContributorResponse\"-\x82\xd3\xe4\x93\x02'\x12%/v2/geoprovenance/countries/component\x12\x8e\x01\n" +
+	"\x12GetComponentOrigin\x12\".scanoss.api.common.v2.PurlRequest\x1a,.scanoss.api.geoprovenance.v2.OriginResponse\"&\x82\xd3\xe4\x93\x02\x1d:\x01*\"\x18/v2/geoprovenance/origin\x88\x02\x01\x12\xa9\x01\n" +
+	"\x15GetOriginByComponents\x12(.scanoss.api.common.v2.ComponentsRequest\x1a6.scanoss.api.geoprovenance.v2.ComponentsOriginResponse\".\x82\xd3\xe4\x93\x02(:\x01*\"#/v2/geoprovenance/origin/components\x12\xa2\x01\n" +
+	"\x14GetOriginByComponent\x12'.scanoss.api.common.v2.ComponentRequest\x1a5.scanoss.api.geoprovenance.v2.ComponentOriginResponse\"*\x82\xd3\xe4\x93\x02$\x12\"/v2/geoprovenance/origin/componentB\xa4\x02\x92A\xe3\x01\x12}\n" +
 	"\x1eSCANOSS GEO Provenance Service\"V\n" +
 	"\x15scanoss-geoprovenance\x12(https://github.com/scanoss/geoprovenance\x1a\x13support@scanoss.com2\x032.0*\x01\x012\x10application/json:\x10application/jsonR;\n" +
 	"\x03404\x124\n" +
@@ -497,39 +886,66 @@ func file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescGZIP()
 	return file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDescData
 }
 
-var file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_goTypes = []any{
-	(*ContributorResponse)(nil),                  // 0: scanoss.api.geoprovenance.v2.ContributorResponse
-	(*OriginResponse)(nil),                       // 1: scanoss.api.geoprovenance.v2.OriginResponse
-	(*ContributorResponse_DeclaredLocation)(nil), // 2: scanoss.api.geoprovenance.v2.ContributorResponse.DeclaredLocation
-	(*ContributorResponse_CuratedLocation)(nil),  // 3: scanoss.api.geoprovenance.v2.ContributorResponse.CuratedLocation
-	(*ContributorResponse_Purls)(nil),            // 4: scanoss.api.geoprovenance.v2.ContributorResponse.Purls
-	(*OriginResponse_Location)(nil),              // 5: scanoss.api.geoprovenance.v2.OriginResponse.Location
-	(*OriginResponse_Purls)(nil),                 // 6: scanoss.api.geoprovenance.v2.OriginResponse.Purls
-	(*commonv2.StatusResponse)(nil),              // 7: scanoss.api.common.v2.StatusResponse
-	(*commonv2.EchoRequest)(nil),                 // 8: scanoss.api.common.v2.EchoRequest
-	(*commonv2.PurlRequest)(nil),                 // 9: scanoss.api.common.v2.PurlRequest
-	(*commonv2.EchoResponse)(nil),                // 10: scanoss.api.common.v2.EchoResponse
+	(*DeclaredLocation)(nil),              // 0: scanoss.api.geoprovenance.v2.DeclaredLocation
+	(*CuratedLocation)(nil),               // 1: scanoss.api.geoprovenance.v2.CuratedLocation
+	(*ContributorResponse)(nil),           // 2: scanoss.api.geoprovenance.v2.ContributorResponse
+	(*ComponentLocationInfo)(nil),         // 3: scanoss.api.geoprovenance.v2.ComponentLocationInfo
+	(*ComponentsContributorResponse)(nil), // 4: scanoss.api.geoprovenance.v2.ComponentsContributorResponse
+	(*ComponentContributorResponse)(nil),  // 5: scanoss.api.geoprovenance.v2.ComponentContributorResponse
+	(*Location)(nil),                      // 6: scanoss.api.geoprovenance.v2.Location
+	(*ComponentLocation)(nil),             // 7: scanoss.api.geoprovenance.v2.ComponentLocation
+	(*OriginResponse)(nil),                // 8: scanoss.api.geoprovenance.v2.OriginResponse
+	(*ComponentsOriginResponse)(nil),      // 9: scanoss.api.geoprovenance.v2.ComponentsOriginResponse
+	(*ComponentOriginResponse)(nil),       // 10: scanoss.api.geoprovenance.v2.ComponentOriginResponse
+	(*ContributorResponse_Purls)(nil),     // 11: scanoss.api.geoprovenance.v2.ContributorResponse.Purls
+	(*OriginResponse_Purls)(nil),          // 12: scanoss.api.geoprovenance.v2.OriginResponse.Purls
+	(*commonv2.StatusResponse)(nil),       // 13: scanoss.api.common.v2.StatusResponse
+	(*commonv2.EchoRequest)(nil),          // 14: scanoss.api.common.v2.EchoRequest
+	(*commonv2.PurlRequest)(nil),          // 15: scanoss.api.common.v2.PurlRequest
+	(*commonv2.ComponentsRequest)(nil),    // 16: scanoss.api.common.v2.ComponentsRequest
+	(*commonv2.ComponentRequest)(nil),     // 17: scanoss.api.common.v2.ComponentRequest
+	(*commonv2.EchoResponse)(nil),         // 18: scanoss.api.common.v2.EchoResponse
 }
 var file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_depIdxs = []int32{
-	4,  // 0: scanoss.api.geoprovenance.v2.ContributorResponse.purls:type_name -> scanoss.api.geoprovenance.v2.ContributorResponse.Purls
-	7,  // 1: scanoss.api.geoprovenance.v2.ContributorResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	6,  // 2: scanoss.api.geoprovenance.v2.OriginResponse.purls:type_name -> scanoss.api.geoprovenance.v2.OriginResponse.Purls
-	7,  // 3: scanoss.api.geoprovenance.v2.OriginResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	2,  // 4: scanoss.api.geoprovenance.v2.ContributorResponse.Purls.declared_locations:type_name -> scanoss.api.geoprovenance.v2.ContributorResponse.DeclaredLocation
-	3,  // 5: scanoss.api.geoprovenance.v2.ContributorResponse.Purls.curated_locations:type_name -> scanoss.api.geoprovenance.v2.ContributorResponse.CuratedLocation
-	5,  // 6: scanoss.api.geoprovenance.v2.OriginResponse.Purls.locations:type_name -> scanoss.api.geoprovenance.v2.OriginResponse.Location
-	8,  // 7: scanoss.api.geoprovenance.v2.GeoProvenance.Echo:input_type -> scanoss.api.common.v2.EchoRequest
-	9,  // 8: scanoss.api.geoprovenance.v2.GeoProvenance.GetComponentContributors:input_type -> scanoss.api.common.v2.PurlRequest
-	9,  // 9: scanoss.api.geoprovenance.v2.GeoProvenance.GetComponentOrigin:input_type -> scanoss.api.common.v2.PurlRequest
-	10, // 10: scanoss.api.geoprovenance.v2.GeoProvenance.Echo:output_type -> scanoss.api.common.v2.EchoResponse
-	0,  // 11: scanoss.api.geoprovenance.v2.GeoProvenance.GetComponentContributors:output_type -> scanoss.api.geoprovenance.v2.ContributorResponse
-	1,  // 12: scanoss.api.geoprovenance.v2.GeoProvenance.GetComponentOrigin:output_type -> scanoss.api.geoprovenance.v2.OriginResponse
-	10, // [10:13] is the sub-list for method output_type
-	7,  // [7:10] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	11, // 0: scanoss.api.geoprovenance.v2.ContributorResponse.purls:type_name -> scanoss.api.geoprovenance.v2.ContributorResponse.Purls
+	13, // 1: scanoss.api.geoprovenance.v2.ContributorResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	0,  // 2: scanoss.api.geoprovenance.v2.ComponentLocationInfo.declared_locations:type_name -> scanoss.api.geoprovenance.v2.DeclaredLocation
+	1,  // 3: scanoss.api.geoprovenance.v2.ComponentLocationInfo.curated_locations:type_name -> scanoss.api.geoprovenance.v2.CuratedLocation
+	3,  // 4: scanoss.api.geoprovenance.v2.ComponentsContributorResponse.components_locations:type_name -> scanoss.api.geoprovenance.v2.ComponentLocationInfo
+	13, // 5: scanoss.api.geoprovenance.v2.ComponentsContributorResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	3,  // 6: scanoss.api.geoprovenance.v2.ComponentContributorResponse.component_locations:type_name -> scanoss.api.geoprovenance.v2.ComponentLocationInfo
+	13, // 7: scanoss.api.geoprovenance.v2.ComponentContributorResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	6,  // 8: scanoss.api.geoprovenance.v2.ComponentLocation.locations:type_name -> scanoss.api.geoprovenance.v2.Location
+	12, // 9: scanoss.api.geoprovenance.v2.OriginResponse.purls:type_name -> scanoss.api.geoprovenance.v2.OriginResponse.Purls
+	13, // 10: scanoss.api.geoprovenance.v2.OriginResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	7,  // 11: scanoss.api.geoprovenance.v2.ComponentsOriginResponse.components_locations:type_name -> scanoss.api.geoprovenance.v2.ComponentLocation
+	13, // 12: scanoss.api.geoprovenance.v2.ComponentsOriginResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	7,  // 13: scanoss.api.geoprovenance.v2.ComponentOriginResponse.component_locations:type_name -> scanoss.api.geoprovenance.v2.ComponentLocation
+	13, // 14: scanoss.api.geoprovenance.v2.ComponentOriginResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	0,  // 15: scanoss.api.geoprovenance.v2.ContributorResponse.Purls.declared_locations:type_name -> scanoss.api.geoprovenance.v2.DeclaredLocation
+	1,  // 16: scanoss.api.geoprovenance.v2.ContributorResponse.Purls.curated_locations:type_name -> scanoss.api.geoprovenance.v2.CuratedLocation
+	6,  // 17: scanoss.api.geoprovenance.v2.OriginResponse.Purls.locations:type_name -> scanoss.api.geoprovenance.v2.Location
+	14, // 18: scanoss.api.geoprovenance.v2.GeoProvenance.Echo:input_type -> scanoss.api.common.v2.EchoRequest
+	15, // 19: scanoss.api.geoprovenance.v2.GeoProvenance.GetComponentContributors:input_type -> scanoss.api.common.v2.PurlRequest
+	16, // 20: scanoss.api.geoprovenance.v2.GeoProvenance.GetCountryContributorsByComponents:input_type -> scanoss.api.common.v2.ComponentsRequest
+	17, // 21: scanoss.api.geoprovenance.v2.GeoProvenance.GetCountryContributorsByComponent:input_type -> scanoss.api.common.v2.ComponentRequest
+	15, // 22: scanoss.api.geoprovenance.v2.GeoProvenance.GetComponentOrigin:input_type -> scanoss.api.common.v2.PurlRequest
+	16, // 23: scanoss.api.geoprovenance.v2.GeoProvenance.GetOriginByComponents:input_type -> scanoss.api.common.v2.ComponentsRequest
+	17, // 24: scanoss.api.geoprovenance.v2.GeoProvenance.GetOriginByComponent:input_type -> scanoss.api.common.v2.ComponentRequest
+	18, // 25: scanoss.api.geoprovenance.v2.GeoProvenance.Echo:output_type -> scanoss.api.common.v2.EchoResponse
+	2,  // 26: scanoss.api.geoprovenance.v2.GeoProvenance.GetComponentContributors:output_type -> scanoss.api.geoprovenance.v2.ContributorResponse
+	4,  // 27: scanoss.api.geoprovenance.v2.GeoProvenance.GetCountryContributorsByComponents:output_type -> scanoss.api.geoprovenance.v2.ComponentsContributorResponse
+	5,  // 28: scanoss.api.geoprovenance.v2.GeoProvenance.GetCountryContributorsByComponent:output_type -> scanoss.api.geoprovenance.v2.ComponentContributorResponse
+	8,  // 29: scanoss.api.geoprovenance.v2.GeoProvenance.GetComponentOrigin:output_type -> scanoss.api.geoprovenance.v2.OriginResponse
+	9,  // 30: scanoss.api.geoprovenance.v2.GeoProvenance.GetOriginByComponents:output_type -> scanoss.api.geoprovenance.v2.ComponentsOriginResponse
+	10, // 31: scanoss.api.geoprovenance.v2.GeoProvenance.GetOriginByComponent:output_type -> scanoss.api.geoprovenance.v2.ComponentOriginResponse
+	25, // [25:32] is the sub-list for method output_type
+	18, // [18:25] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_init() }
@@ -543,7 +959,7 @@ func file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDesc), len(file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/geoprovenancev2/scanoss-geoprovenance.pb.gw.go
+++ b/api/geoprovenancev2/scanoss-geoprovenance.pb.gw.go
@@ -90,6 +90,68 @@ func local_request_GeoProvenance_GetComponentContributors_0(ctx context.Context,
 	return msg, metadata, err
 }
 
+func request_GeoProvenance_GetCountryContributorsByComponents_0(ctx context.Context, marshaler runtime.Marshaler, client GeoProvenanceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq commonv2.ComponentsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetCountryContributorsByComponents(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_GeoProvenance_GetCountryContributorsByComponents_0(ctx context.Context, marshaler runtime.Marshaler, server GeoProvenanceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq commonv2.ComponentsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetCountryContributorsByComponents(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+var filter_GeoProvenance_GetCountryContributorsByComponent_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_GeoProvenance_GetCountryContributorsByComponent_0(ctx context.Context, marshaler runtime.Marshaler, client GeoProvenanceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq commonv2.ComponentRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_GeoProvenance_GetCountryContributorsByComponent_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.GetCountryContributorsByComponent(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_GeoProvenance_GetCountryContributorsByComponent_0(ctx context.Context, marshaler runtime.Marshaler, server GeoProvenanceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq commonv2.ComponentRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_GeoProvenance_GetCountryContributorsByComponent_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetCountryContributorsByComponent(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_GeoProvenance_GetComponentOrigin_0(ctx context.Context, marshaler runtime.Marshaler, client GeoProvenanceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq commonv2.PurlRequest
@@ -114,6 +176,68 @@ func local_request_GeoProvenance_GetComponentOrigin_0(ctx context.Context, marsh
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := server.GetComponentOrigin(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_GeoProvenance_GetOriginByComponents_0(ctx context.Context, marshaler runtime.Marshaler, client GeoProvenanceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq commonv2.ComponentsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetOriginByComponents(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_GeoProvenance_GetOriginByComponents_0(ctx context.Context, marshaler runtime.Marshaler, server GeoProvenanceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq commonv2.ComponentsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetOriginByComponents(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+var filter_GeoProvenance_GetOriginByComponent_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_GeoProvenance_GetOriginByComponent_0(ctx context.Context, marshaler runtime.Marshaler, client GeoProvenanceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq commonv2.ComponentRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_GeoProvenance_GetOriginByComponent_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.GetOriginByComponent(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_GeoProvenance_GetOriginByComponent_0(ctx context.Context, marshaler runtime.Marshaler, server GeoProvenanceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq commonv2.ComponentRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_GeoProvenance_GetOriginByComponent_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetOriginByComponent(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -163,6 +287,46 @@ func RegisterGeoProvenanceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_GeoProvenance_GetComponentContributors_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_GeoProvenance_GetCountryContributorsByComponents_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/scanoss.api.geoprovenance.v2.GeoProvenance/GetCountryContributorsByComponents", runtime.WithHTTPPathPattern("/v2/geoprovenance/countries/components"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_GeoProvenance_GetCountryContributorsByComponents_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_GeoProvenance_GetCountryContributorsByComponents_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_GeoProvenance_GetCountryContributorsByComponent_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/scanoss.api.geoprovenance.v2.GeoProvenance/GetCountryContributorsByComponent", runtime.WithHTTPPathPattern("/v2/geoprovenance/countries/component"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_GeoProvenance_GetCountryContributorsByComponent_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_GeoProvenance_GetCountryContributorsByComponent_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_GeoProvenance_GetComponentOrigin_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -182,6 +346,46 @@ func RegisterGeoProvenanceHandlerServer(ctx context.Context, mux *runtime.ServeM
 			return
 		}
 		forward_GeoProvenance_GetComponentOrigin_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_GeoProvenance_GetOriginByComponents_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/scanoss.api.geoprovenance.v2.GeoProvenance/GetOriginByComponents", runtime.WithHTTPPathPattern("/v2/geoprovenance/origin/components"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_GeoProvenance_GetOriginByComponents_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_GeoProvenance_GetOriginByComponents_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_GeoProvenance_GetOriginByComponent_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/scanoss.api.geoprovenance.v2.GeoProvenance/GetOriginByComponent", runtime.WithHTTPPathPattern("/v2/geoprovenance/origin/component"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_GeoProvenance_GetOriginByComponent_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_GeoProvenance_GetOriginByComponent_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -257,6 +461,40 @@ func RegisterGeoProvenanceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_GeoProvenance_GetComponentContributors_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_GeoProvenance_GetCountryContributorsByComponents_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/scanoss.api.geoprovenance.v2.GeoProvenance/GetCountryContributorsByComponents", runtime.WithHTTPPathPattern("/v2/geoprovenance/countries/components"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_GeoProvenance_GetCountryContributorsByComponents_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_GeoProvenance_GetCountryContributorsByComponents_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_GeoProvenance_GetCountryContributorsByComponent_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/scanoss.api.geoprovenance.v2.GeoProvenance/GetCountryContributorsByComponent", runtime.WithHTTPPathPattern("/v2/geoprovenance/countries/component"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_GeoProvenance_GetCountryContributorsByComponent_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_GeoProvenance_GetCountryContributorsByComponent_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_GeoProvenance_GetComponentOrigin_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -274,17 +512,59 @@ func RegisterGeoProvenanceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_GeoProvenance_GetComponentOrigin_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_GeoProvenance_GetOriginByComponents_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/scanoss.api.geoprovenance.v2.GeoProvenance/GetOriginByComponents", runtime.WithHTTPPathPattern("/v2/geoprovenance/origin/components"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_GeoProvenance_GetOriginByComponents_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_GeoProvenance_GetOriginByComponents_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_GeoProvenance_GetOriginByComponent_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/scanoss.api.geoprovenance.v2.GeoProvenance/GetOriginByComponent", runtime.WithHTTPPathPattern("/v2/geoprovenance/origin/component"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_GeoProvenance_GetOriginByComponent_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_GeoProvenance_GetOriginByComponent_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_GeoProvenance_Echo_0                     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v2", "geoprovenance", "echo"}, ""))
-	pattern_GeoProvenance_GetComponentContributors_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v2", "geoprovenance", "countries"}, ""))
-	pattern_GeoProvenance_GetComponentOrigin_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v2", "geoprovenance", "origin"}, ""))
+	pattern_GeoProvenance_Echo_0                               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v2", "geoprovenance", "echo"}, ""))
+	pattern_GeoProvenance_GetComponentContributors_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v2", "geoprovenance", "countries"}, ""))
+	pattern_GeoProvenance_GetCountryContributorsByComponents_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v2", "geoprovenance", "countries", "components"}, ""))
+	pattern_GeoProvenance_GetCountryContributorsByComponent_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v2", "geoprovenance", "countries", "component"}, ""))
+	pattern_GeoProvenance_GetComponentOrigin_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v2", "geoprovenance", "origin"}, ""))
+	pattern_GeoProvenance_GetOriginByComponents_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v2", "geoprovenance", "origin", "components"}, ""))
+	pattern_GeoProvenance_GetOriginByComponent_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v2", "geoprovenance", "origin", "component"}, ""))
 )
 
 var (
-	forward_GeoProvenance_Echo_0                     = runtime.ForwardResponseMessage
-	forward_GeoProvenance_GetComponentContributors_0 = runtime.ForwardResponseMessage
-	forward_GeoProvenance_GetComponentOrigin_0       = runtime.ForwardResponseMessage
+	forward_GeoProvenance_Echo_0                               = runtime.ForwardResponseMessage
+	forward_GeoProvenance_GetComponentContributors_0           = runtime.ForwardResponseMessage
+	forward_GeoProvenance_GetCountryContributorsByComponents_0 = runtime.ForwardResponseMessage
+	forward_GeoProvenance_GetCountryContributorsByComponent_0  = runtime.ForwardResponseMessage
+	forward_GeoProvenance_GetComponentOrigin_0                 = runtime.ForwardResponseMessage
+	forward_GeoProvenance_GetOriginByComponents_0              = runtime.ForwardResponseMessage
+	forward_GeoProvenance_GetOriginByComponent_0               = runtime.ForwardResponseMessage
 )

--- a/api/geoprovenancev2/scanoss-geoprovenance_grpc.pb.go
+++ b/api/geoprovenancev2/scanoss-geoprovenance_grpc.pb.go
@@ -46,9 +46,13 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	GeoProvenance_Echo_FullMethodName                     = "/scanoss.api.geoprovenance.v2.GeoProvenance/Echo"
-	GeoProvenance_GetComponentContributors_FullMethodName = "/scanoss.api.geoprovenance.v2.GeoProvenance/GetComponentContributors"
-	GeoProvenance_GetComponentOrigin_FullMethodName       = "/scanoss.api.geoprovenance.v2.GeoProvenance/GetComponentOrigin"
+	GeoProvenance_Echo_FullMethodName                               = "/scanoss.api.geoprovenance.v2.GeoProvenance/Echo"
+	GeoProvenance_GetComponentContributors_FullMethodName           = "/scanoss.api.geoprovenance.v2.GeoProvenance/GetComponentContributors"
+	GeoProvenance_GetCountryContributorsByComponents_FullMethodName = "/scanoss.api.geoprovenance.v2.GeoProvenance/GetCountryContributorsByComponents"
+	GeoProvenance_GetCountryContributorsByComponent_FullMethodName  = "/scanoss.api.geoprovenance.v2.GeoProvenance/GetCountryContributorsByComponent"
+	GeoProvenance_GetComponentOrigin_FullMethodName                 = "/scanoss.api.geoprovenance.v2.GeoProvenance/GetComponentOrigin"
+	GeoProvenance_GetOriginByComponents_FullMethodName              = "/scanoss.api.geoprovenance.v2.GeoProvenance/GetOriginByComponents"
+	GeoProvenance_GetOriginByComponent_FullMethodName               = "/scanoss.api.geoprovenance.v2.GeoProvenance/GetOriginByComponent"
 )
 
 // GeoProvenanceClient is the client API for GeoProvenance service.
@@ -58,12 +62,34 @@ const (
 // *
 // Expose all of the SCANOSS Geo Provenance RPCs here
 type GeoProvenanceClient interface {
-	// Standard echo
+	// Standard health check endpoint to verify service availability and connectivity
 	Echo(ctx context.Context, in *commonv2.EchoRequest, opts ...grpc.CallOption) (*commonv2.EchoResponse, error)
-	// Get component-level Geo Provenance based on contributor declared location
+	// Deprecated: Do not use.
+	// [DEPRECATED] Get component-level Geo Provenance based on contributor declared location
+	// This method accepts PURL-based requests and is deprecated in favor of GetCountryContributorsByComponent
+	// which accepts ComponentRequest for better component identification
 	GetComponentContributors(ctx context.Context, in *commonv2.PurlRequest, opts ...grpc.CallOption) (*ContributorResponse, error)
-	// Get component-level Geo Provenance based on contributor origin commit times
+	// Get component-level Geo Provenance based on contributor declared location
+	// This is the current method that accepts ComponentsRequest for enhanced component identification
+	// Replaces the deprecated GetComponentContributors method
+	GetCountryContributorsByComponents(ctx context.Context, in *commonv2.ComponentsRequest, opts ...grpc.CallOption) (*ComponentsContributorResponse, error)
+	// Get component-level Geo Provenance based on contributor declared location
+	// This is the current method that accepts ComponentRequest for enhanced component identification
+	// Replaces the deprecated GetComponentContributors method
+	GetCountryContributorsByComponent(ctx context.Context, in *commonv2.ComponentRequest, opts ...grpc.CallOption) (*ComponentContributorResponse, error)
+	// Deprecated: Do not use.
+	// [DEPRECATED] Get component-level Geo Provenance based on contributor origin commit times
+	// This method accepts PURL-based requests and is deprecated in favor of GetOriginByComponent
+	// which accepts ComponentRequest for better component identification
 	GetComponentOrigin(ctx context.Context, in *commonv2.PurlRequest, opts ...grpc.CallOption) (*OriginResponse, error)
+	// Get component-level Geo Provenance based on contributor origin commit times
+	// This is the current method that accepts ComponentsRequest for enhanced component identification
+	// Replaces the deprecated GetComponentOrigin method
+	GetOriginByComponents(ctx context.Context, in *commonv2.ComponentsRequest, opts ...grpc.CallOption) (*ComponentsOriginResponse, error)
+	// Get component-level Geo Provenance based on contributor origin commit times
+	// This is the current method that accepts ComponentRequest for enhanced component identification
+	// Replaces the deprecated GetComponentOrigin method
+	GetOriginByComponent(ctx context.Context, in *commonv2.ComponentRequest, opts ...grpc.CallOption) (*ComponentOriginResponse, error)
 }
 
 type geoProvenanceClient struct {
@@ -84,6 +110,7 @@ func (c *geoProvenanceClient) Echo(ctx context.Context, in *commonv2.EchoRequest
 	return out, nil
 }
 
+// Deprecated: Do not use.
 func (c *geoProvenanceClient) GetComponentContributors(ctx context.Context, in *commonv2.PurlRequest, opts ...grpc.CallOption) (*ContributorResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ContributorResponse)
@@ -94,10 +121,51 @@ func (c *geoProvenanceClient) GetComponentContributors(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *geoProvenanceClient) GetCountryContributorsByComponents(ctx context.Context, in *commonv2.ComponentsRequest, opts ...grpc.CallOption) (*ComponentsContributorResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ComponentsContributorResponse)
+	err := c.cc.Invoke(ctx, GeoProvenance_GetCountryContributorsByComponents_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *geoProvenanceClient) GetCountryContributorsByComponent(ctx context.Context, in *commonv2.ComponentRequest, opts ...grpc.CallOption) (*ComponentContributorResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ComponentContributorResponse)
+	err := c.cc.Invoke(ctx, GeoProvenance_GetCountryContributorsByComponent_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Deprecated: Do not use.
 func (c *geoProvenanceClient) GetComponentOrigin(ctx context.Context, in *commonv2.PurlRequest, opts ...grpc.CallOption) (*OriginResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(OriginResponse)
 	err := c.cc.Invoke(ctx, GeoProvenance_GetComponentOrigin_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *geoProvenanceClient) GetOriginByComponents(ctx context.Context, in *commonv2.ComponentsRequest, opts ...grpc.CallOption) (*ComponentsOriginResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ComponentsOriginResponse)
+	err := c.cc.Invoke(ctx, GeoProvenance_GetOriginByComponents_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *geoProvenanceClient) GetOriginByComponent(ctx context.Context, in *commonv2.ComponentRequest, opts ...grpc.CallOption) (*ComponentOriginResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ComponentOriginResponse)
+	err := c.cc.Invoke(ctx, GeoProvenance_GetOriginByComponent_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -111,12 +179,34 @@ func (c *geoProvenanceClient) GetComponentOrigin(ctx context.Context, in *common
 // *
 // Expose all of the SCANOSS Geo Provenance RPCs here
 type GeoProvenanceServer interface {
-	// Standard echo
+	// Standard health check endpoint to verify service availability and connectivity
 	Echo(context.Context, *commonv2.EchoRequest) (*commonv2.EchoResponse, error)
-	// Get component-level Geo Provenance based on contributor declared location
+	// Deprecated: Do not use.
+	// [DEPRECATED] Get component-level Geo Provenance based on contributor declared location
+	// This method accepts PURL-based requests and is deprecated in favor of GetCountryContributorsByComponent
+	// which accepts ComponentRequest for better component identification
 	GetComponentContributors(context.Context, *commonv2.PurlRequest) (*ContributorResponse, error)
-	// Get component-level Geo Provenance based on contributor origin commit times
+	// Get component-level Geo Provenance based on contributor declared location
+	// This is the current method that accepts ComponentsRequest for enhanced component identification
+	// Replaces the deprecated GetComponentContributors method
+	GetCountryContributorsByComponents(context.Context, *commonv2.ComponentsRequest) (*ComponentsContributorResponse, error)
+	// Get component-level Geo Provenance based on contributor declared location
+	// This is the current method that accepts ComponentRequest for enhanced component identification
+	// Replaces the deprecated GetComponentContributors method
+	GetCountryContributorsByComponent(context.Context, *commonv2.ComponentRequest) (*ComponentContributorResponse, error)
+	// Deprecated: Do not use.
+	// [DEPRECATED] Get component-level Geo Provenance based on contributor origin commit times
+	// This method accepts PURL-based requests and is deprecated in favor of GetOriginByComponent
+	// which accepts ComponentRequest for better component identification
 	GetComponentOrigin(context.Context, *commonv2.PurlRequest) (*OriginResponse, error)
+	// Get component-level Geo Provenance based on contributor origin commit times
+	// This is the current method that accepts ComponentsRequest for enhanced component identification
+	// Replaces the deprecated GetComponentOrigin method
+	GetOriginByComponents(context.Context, *commonv2.ComponentsRequest) (*ComponentsOriginResponse, error)
+	// Get component-level Geo Provenance based on contributor origin commit times
+	// This is the current method that accepts ComponentRequest for enhanced component identification
+	// Replaces the deprecated GetComponentOrigin method
+	GetOriginByComponent(context.Context, *commonv2.ComponentRequest) (*ComponentOriginResponse, error)
 	mustEmbedUnimplementedGeoProvenanceServer()
 }
 
@@ -133,8 +223,20 @@ func (UnimplementedGeoProvenanceServer) Echo(context.Context, *commonv2.EchoRequ
 func (UnimplementedGeoProvenanceServer) GetComponentContributors(context.Context, *commonv2.PurlRequest) (*ContributorResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetComponentContributors not implemented")
 }
+func (UnimplementedGeoProvenanceServer) GetCountryContributorsByComponents(context.Context, *commonv2.ComponentsRequest) (*ComponentsContributorResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetCountryContributorsByComponents not implemented")
+}
+func (UnimplementedGeoProvenanceServer) GetCountryContributorsByComponent(context.Context, *commonv2.ComponentRequest) (*ComponentContributorResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetCountryContributorsByComponent not implemented")
+}
 func (UnimplementedGeoProvenanceServer) GetComponentOrigin(context.Context, *commonv2.PurlRequest) (*OriginResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetComponentOrigin not implemented")
+}
+func (UnimplementedGeoProvenanceServer) GetOriginByComponents(context.Context, *commonv2.ComponentsRequest) (*ComponentsOriginResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetOriginByComponents not implemented")
+}
+func (UnimplementedGeoProvenanceServer) GetOriginByComponent(context.Context, *commonv2.ComponentRequest) (*ComponentOriginResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetOriginByComponent not implemented")
 }
 func (UnimplementedGeoProvenanceServer) mustEmbedUnimplementedGeoProvenanceServer() {}
 func (UnimplementedGeoProvenanceServer) testEmbeddedByValue()                       {}
@@ -193,6 +295,42 @@ func _GeoProvenance_GetComponentContributors_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _GeoProvenance_GetCountryContributorsByComponents_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(commonv2.ComponentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GeoProvenanceServer).GetCountryContributorsByComponents(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GeoProvenance_GetCountryContributorsByComponents_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GeoProvenanceServer).GetCountryContributorsByComponents(ctx, req.(*commonv2.ComponentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _GeoProvenance_GetCountryContributorsByComponent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(commonv2.ComponentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GeoProvenanceServer).GetCountryContributorsByComponent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GeoProvenance_GetCountryContributorsByComponent_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GeoProvenanceServer).GetCountryContributorsByComponent(ctx, req.(*commonv2.ComponentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _GeoProvenance_GetComponentOrigin_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(commonv2.PurlRequest)
 	if err := dec(in); err != nil {
@@ -207,6 +345,42 @@ func _GeoProvenance_GetComponentOrigin_Handler(srv interface{}, ctx context.Cont
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(GeoProvenanceServer).GetComponentOrigin(ctx, req.(*commonv2.PurlRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _GeoProvenance_GetOriginByComponents_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(commonv2.ComponentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GeoProvenanceServer).GetOriginByComponents(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GeoProvenance_GetOriginByComponents_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GeoProvenanceServer).GetOriginByComponents(ctx, req.(*commonv2.ComponentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _GeoProvenance_GetOriginByComponent_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(commonv2.ComponentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GeoProvenanceServer).GetOriginByComponent(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GeoProvenance_GetOriginByComponent_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GeoProvenanceServer).GetOriginByComponent(ctx, req.(*commonv2.ComponentRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -227,8 +401,24 @@ var GeoProvenance_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _GeoProvenance_GetComponentContributors_Handler,
 		},
 		{
+			MethodName: "GetCountryContributorsByComponents",
+			Handler:    _GeoProvenance_GetCountryContributorsByComponents_Handler,
+		},
+		{
+			MethodName: "GetCountryContributorsByComponent",
+			Handler:    _GeoProvenance_GetCountryContributorsByComponent_Handler,
+		},
+		{
 			MethodName: "GetComponentOrigin",
 			Handler:    _GeoProvenance_GetComponentOrigin_Handler,
+		},
+		{
+			MethodName: "GetOriginByComponents",
+			Handler:    _GeoProvenance_GetOriginByComponents_Handler,
+		},
+		{
+			MethodName: "GetOriginByComponent",
+			Handler:    _GeoProvenance_GetOriginByComponent_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/scanningv2/scanoss-scanning.pb.go
+++ b/api/scanningv2/scanoss-scanning.pb.go
@@ -492,23 +492,23 @@ var File_scanoss_api_scanning_v2_scanoss_scanning_proto protoreflect.FileDescrip
 
 const file_scanoss_api_scanning_v2_scanoss_scanning_proto_rawDesc = "" +
 	"\n" +
-	".scanoss/api/scanning/v2/scanoss-scanning.proto\x12\x17scanoss.api.scanning.v2\x1a*scanoss/api/common/v2/scanoss-common.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\xac\x05\n" +
+	".scanoss/api/scanning/v2/scanoss-scanning.proto\x12\x17scanoss.api.scanning.v2\x1a*scanoss/api/common/v2/scanoss-common.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\xb6\x05\n" +
 	"\n" +
 	"HFHRequest\x12@\n" +
-	"\x04root\x18\x01 \x01(\v2,.scanoss.api.scanning.v2.HFHRequest.ChildrenR\x04root\x12%\n" +
-	"\x0erank_threshold\x18\x02 \x01(\x05R\rrankThreshold\x12\x1a\n" +
+	"\x04root\x18\x01 \x01(\v2,.scanoss.api.scanning.v2.HFHRequest.ChildrenR\x04root\x12&\n" +
+	"\x0erank_threshold\x18\x02 \x01(\x05R\x0erank_threshold\x12\x1a\n" +
 	"\bcategory\x18\x03 \x01(\tR\bcategory\x12\x1f\n" +
 	"\vquery_limit\x18\x04 \x01(\x05R\n" +
 	"queryLimit\x12/\n" +
 	"\x13recursive_threshold\x18\x05 \x01(\x02R\x12recursiveThreshold\x12,\n" +
-	"\x12min_accepted_score\x18\x06 \x01(\x02R\x10minAcceptedScore\x1a\x98\x03\n" +
-	"\bChildren\x12\x17\n" +
-	"\apath_id\x18\x01 \x01(\tR\x06pathId\x12$\n" +
-	"\x0esim_hash_names\x18\x02 \x01(\tR\fsimHashNames\x12(\n" +
-	"\x10sim_hash_content\x18\x03 \x01(\tR\x0esimHashContent\x12H\n" +
-	"\bchildren\x18\x04 \x03(\v2,.scanoss.api.scanning.v2.HFHRequest.ChildrenR\bchildren\x12+\n" +
-	"\x12sim_hash_dir_names\x18\x05 \x01(\tR\x0fsimHashDirNames\x12i\n" +
-	"\x0flang_extensions\x18\x06 \x03(\v2@.scanoss.api.scanning.v2.HFHRequest.Children.LangExtensionsEntryR\x0elangExtensions\x1aA\n" +
+	"\x12min_accepted_score\x18\x06 \x01(\x02R\x10minAcceptedScore\x1a\xa1\x03\n" +
+	"\bChildren\x12\x18\n" +
+	"\apath_id\x18\x01 \x01(\tR\apath_id\x12&\n" +
+	"\x0esim_hash_names\x18\x02 \x01(\tR\x0esim_hash_names\x12*\n" +
+	"\x10sim_hash_content\x18\x03 \x01(\tR\x10sim_hash_content\x12H\n" +
+	"\bchildren\x18\x04 \x03(\v2,.scanoss.api.scanning.v2.HFHRequest.ChildrenR\bchildren\x12.\n" +
+	"\x12sim_hash_dir_names\x18\x05 \x01(\tR\x12sim_hash_dir_names\x12j\n" +
+	"\x0flang_extensions\x18\x06 \x03(\v2@.scanoss.api.scanning.v2.HFHRequest.Children.LangExtensionsEntryR\x0flang_extensions\x1aA\n" +
 	"\x13LangExtensionsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\x84\x04\n" +

--- a/protobuf/scanoss/api/geoprovenance/v2/README.md
+++ b/protobuf/scanoss/api/geoprovenance/v2/README.md
@@ -1,0 +1,473 @@
+# SCANOSS Geo Provenance Service API v2
+
+Provides geographical origin analysis for software components by examining contributor locations, commit patterns, and development activity across different regions.
+
+## GetCountryContributorsByComponents
+
+Retrieves geographical provenance information based on contributor declared locations for software components. Analyzes repository metadata and contributor profiles to determine the geographical distribution of development activity.
+
+### Request Format
+See [Common API Types](../common/v2/README.md) for `ComponentsRequest` documentation.
+
+### HTTP Request Example
+```bash
+curl -X POST 'https://api.scanoss.com/v2/geoprovenance/countries/components' \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: $SC_API_KEY' \
+  -d '{
+    "components": [
+      "pkg:github/scanoss/engine@5.0.0"
+    ]
+  }'
+```
+
+### gRPC Request Example
+```bash
+grpcurl -H "x-api-key: $SC_API_KEY" \
+  -d '{
+    "components": [
+      "pkg:github/scanoss/engine@5.0.0"
+    ]
+  }' \
+  api.scanoss.com:443 \
+  scanoss.api.geoprovenance.v2.GeoProvenance/GetCountryContributorsByComponents
+```
+
+### Response Format
+
+The method returns geographical contributor information including:
+
+- `components_locations` array: Contains geo-provenance data for each requested component
+- `status` field: Response status indicating success or failure of the request
+
+Each component object contains:
+- `purl`: Package URL identifying the component
+- `declared_locations`: Locations declared by contributors in their profiles or repository metadata
+- `curated_locations`: SCANOSS-curated geographical data based on analysis
+
+### Response Examples
+
+#### Component with Geographic Distribution
+```json
+{
+  "components_locations": [
+    {
+      "purl": "pkg:github/scanoss/engine@5.0.0",
+      "declared_locations": [
+        {
+          "type": "owner",
+          "location": "Barcelona, Spain"
+        },
+        {
+          "type": "contributor",
+          "location": "Berlin, Germany"
+        }
+      ],
+      "curated_locations": [
+        {
+          "country": "Spain",
+          "count": 8
+        },
+        {
+          "country": "Germany",
+          "count": 3
+        },
+        {
+          "country": "United States",
+          "count": 2
+        }
+      ]
+    }
+  ],
+  "status": {
+    "status": "SUCCESS",
+    "message": "Geo-provenance successfully retrieved"
+  }
+}
+```
+
+#### Component with Limited Geographic Data
+```json
+{
+  "components_locations": [
+    {
+      "purl": "pkg:npm/simple-utility@1.0.0",
+      "declared_locations": [],
+      "curated_locations": [
+        {
+          "country": "United States",
+          "count": 1
+        }
+      ]
+    }
+  ],
+  "status": {
+    "status": "SUCCESS",
+    "message": "Geo-provenance successfully retrieved"
+  }
+}
+```
+
+## GetCountryContributorsByComponent
+
+Retrieves geographical provenance information for a single component based on contributor declared locations. Analyzes repository metadata and contributor profiles to determine the geographical distribution of development activity.
+
+### Request Format
+See [Common API Types](../common/v2/README.md) for `ComponentRequest` documentation.
+
+### HTTP Request Example
+```bash
+curl -X GET 'https://api.scanoss.com/v2/geoprovenance/countries/component?purl=pkg:github/scanoss/engine@5.0.0' \
+  -H 'x-api-key: $SC_API_KEY'
+```
+
+### gRPC Request Example
+```bash
+grpcurl -H "x-api-key: $SC_API_KEY" \
+  -d '{
+    "purl": "pkg:github/scanoss/engine@5.0.0"
+  }' \
+  api.scanoss.com:443 \
+  scanoss.api.geoprovenance.v2.GeoProvenance/GetCountryContributorsByComponent
+```
+
+### Response Format
+
+The method returns geographical contributor information including:
+
+- `component_locations` object: Contains geo-provenance data for the requested component
+- `status` field: Response status indicating success or failure of the request
+
+The component object contains:
+- `purl`: Package URL identifying the component
+- `declared_locations`: Locations declared by contributors in their profiles or repository metadata
+- `curated_locations`: SCANOSS-curated geographical data based on analysis
+
+### Response Examples
+
+#### Component with Geographic Distribution
+```json
+{
+  "component_locations": {
+    "purl": "pkg:github/scanoss/engine@5.0.0",
+    "declared_locations": [
+      {
+        "type": "owner",
+        "location": "Barcelona, Spain"
+      },
+      {
+        "type": "contributor",
+        "location": "Berlin, Germany"
+      }
+    ],
+    "curated_locations": [
+      {
+        "country": "Spain",
+        "count": 8
+      },
+      {
+        "country": "Germany",
+        "count": 3
+      },
+      {
+        "country": "United States",
+        "count": 2
+      }
+    ]
+  },
+  "status": {
+    "status": "SUCCESS",
+    "message": "Geo-provenance successfully retrieved"
+  }
+}
+```
+
+#### Component with Limited Geographic Data
+```json
+{
+  "component_locations": {
+    "purl": "pkg:npm/simple-utility@1.0.0",
+    "declared_locations": [],
+    "curated_locations": [
+      {
+        "country": "United States",
+        "count": 1
+      }
+    ]
+  },
+  "status": {
+    "status": "SUCCESS",
+    "message": "Geo-provenance successfully retrieved"
+  }
+}
+```
+
+## GetComponentContributors (Deprecated)
+
+**Note: This method is deprecated and will be removed in a future version. Please use GetCountryContributorsByComponents instead.**
+
+Legacy method for analyzing geographical contributor information using PURL-based requests. Provides the same functionality as GetCountryContributorsByComponents but with the older request format.
+
+### Request Format
+See [Common API Types](../common/v2/README.md) for `PurlRequest` documentation.
+
+### HTTP Request Example
+```bash
+curl -X POST 'https://api.scanoss.com/v2/geoprovenance/countries' \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: $SC_API_KEY' \
+  -d '{
+    "purls": [
+      "pkg:github/scanoss/engine@5.0.0"
+    ]
+  }'
+```
+
+### Migration Guide
+To migrate from `GetComponentContributors` to `GetCountryContributorsByComponents`:
+
+1. **Change the endpoint**: `/v2/geoprovenance/countries` � `/v2/geoprovenance/countries/component`
+2. **Update request format**: Use `ComponentsRequest` instead of `PurlRequest`
+3. **Update response handling**: Use `ComponentsContributorResponse` instead of `ContributorResponse`
+
+
+## GetOriginByComponents
+
+Retrieves geographical origin information based on contributor commit timing patterns and development activity analysis. This method examines when contributors are most active to infer their likely geographical locations.
+
+### Request Format
+See [Common API Types](../common/v2/README.md) for `ComponentsRequest` documentation.
+
+### HTTP Request Example
+```bash
+curl -X POST 'https://api.scanoss.com/v2/geoprovenance/origin/components' \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: $SC_API_KEY' \
+  -d '{
+    "components": [
+      "pkg:github/scanoss/engine@5.0.0"
+    ]
+  }'
+```
+
+### gRPC Request Example
+```bash
+grpcurl -H "x-api-key: $SC_API_KEY" \
+  -d  '{
+    "components": [
+      "pkg:github/scanoss/engine@5.0.0"
+    ]
+  }' \
+  api.scanoss.com:443 \
+  scanoss.api.geoprovenance.v2.GeoProvenance/GetOriginByComponents
+```
+
+### Response Format
+
+The method returns commit-time based geographical analysis including:
+
+- `components_locations` array: Contains geographical origin data based on commit patterns
+- `status` field: Response status indicating success or failure of the request
+
+Each component location object contains:
+- `purl`: Package URL identifying the component
+- `locations`: Array of countries with contributor percentages based on commit timing analysis
+
+### Response Examples
+
+#### Component with Origin Analysis
+```json
+{
+  "components_locations": [
+    {
+      "purl": "pkg:github/scanoss/engine@5.0.0",
+      "locations": [
+        {
+          "name": "ES",
+          "percentage": 65.5
+        },
+        {
+          "name": "DE",
+          "percentage": 20.3
+        },
+        {
+          "name": "US",
+          "percentage": 14.2
+        }
+      ]
+    }
+  ],
+  "status": {
+    "status": "SUCCESS",
+    "message": "Geo-provenance origin successfully retrieved"
+  }
+}
+```
+
+#### Component with Single Origin
+```json
+{
+  "components_locations": [
+    {
+      "purl": "pkg:npm/private-utility@2.1.0",
+      "locations": [
+        {
+          "name": "US",
+          "percentage": 100.0
+        }
+      ]
+    }
+  ],
+  "status": {
+    "status": "SUCCESS",
+    "message": "Geo-provenance origin successfully retrieved"
+  }
+}
+```
+
+
+## GetOriginByComponent
+
+Retrieves geographical origin information for a single component based on contributor commit timing patterns and development activity analysis. This method examines when contributors are most active to infer their likely geographical locations.
+
+### Request Format
+See [Common API Types](../common/v2/README.md) for `ComponentRequest` documentation.
+
+### HTTP Request Example
+```bash
+curl -X GET 'https://api.scanoss.com/v2/geoprovenance/origin/component?purl=pkg:github/scanoss/engine@5.0.0' \
+  -H 'x-api-key: $SC_API_KEY'
+```
+
+### gRPC Request Example
+```bash
+grpcurl -H "x-api-key: $SC_API_KEY" \
+  -d '{
+    "purl": "pkg:github/scanoss/engine@5.0.0"
+  }' \
+  api.scanoss.com:443 \
+  scanoss.api.geoprovenance.v2.GeoProvenance/GetOriginByComponent
+```
+
+### Response Format
+
+The method returns commit-time based geographical analysis including:
+
+- `component_locations` object: Contains geographical origin data based on commit patterns for the requested component
+- `status` field: Response status indicating success or failure of the request
+
+The component location object contains:
+- `purl`: Package URL identifying the component
+- `locations`: Array of countries with contributor percentages based on commit timing analysis
+
+### Response Examples
+
+#### Component with Origin Analysis
+```json
+{
+  "component_locations": {
+    "purl": "pkg:github/scanoss/engine@5.0.0",
+    "locations": [
+      {
+        "name": "ES",
+        "percentage": 65.5
+      },
+      {
+        "name": "DE",
+        "percentage": 20.3
+      },
+      {
+        "name": "US",
+        "percentage": 14.2
+      }
+    ]
+  },
+  "status": {
+    "status": "SUCCESS",
+    "message": "Geo-provenance origin successfully retrieved"
+  }
+}
+```
+
+#### Component with Single Origin
+```json
+{
+  "component_locations": {
+    "purl": "pkg:npm/private-utility@2.1.0",
+    "locations": [
+      {
+        "name": "US",
+        "percentage": 100.0
+      }
+    ]
+  },
+  "status": {
+    "status": "SUCCESS",
+    "message": "Geo-provenance origin successfully retrieved"
+  }
+}
+```
+
+## GetComponentOrigin (Deprecated)
+
+**Note: This method is deprecated and will be removed in a future version. Please use GetOriginByComponents instead.**
+
+Legacy method for analyzing geographical origin information using PURL-based requests. Provides the same functionality as GetOriginByComponents but with the older request format.
+
+### Request Format
+See [Common API Types](../common/v2/README.md) for `PurlRequest` documentation.
+
+### HTTP Request Example
+```bash
+curl -X POST 'https://api.scanoss.com/v2/geoprovenance/origin' \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: $SC_API_KEY' \
+  -d '{
+    "purls": [
+      "pkg:github/scanoss/engine@5.0.0"
+    ]
+  }'
+```
+
+
+### Migration Guide
+To migrate from `GetComponentOrigin` to `GetOriginByComponents`:
+
+1. **Change the endpoint**: `/v2/geoprovenance/origin` � `/v2/geoprovenance/origin/components`
+2. **Update request format**: Use `ComponentsRequest` instead of `PurlRequest`
+3. **Update response handling**: Use `ComponentsOriginResponse` instead of `OriginResponse`
+
+## Echo
+
+Standard service health check endpoint for testing connectivity and API key validation.
+
+### HTTP Request Example
+```bash
+curl -X POST 'https://api.scanoss.com/v2/geoprovenance/echo' \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: $SC_API_KEY' \
+  -d '{"message": "test"}'
+```
+
+### gRPC Request Example
+```bash
+grpcurl -H "x-api-key: $SC_API_KEY" \
+  -d '{"message": "test"}' \
+  api.scanoss.com:443 \
+  scanoss.api.geoprovenance.v2.GeoProvenance/Echo
+```
+
+## Analysis Methods
+
+The Geo Provenance service employs two complementary analysis approaches:
+
+### Declared Location Analysis
+- Examines contributor profiles and repository metadata
+- Identifies locations explicitly declared by project maintainers and contributors
+
+### Commit Timing Analysis
+- Analyzes commit timestamps and patterns to infer contributor time zones
+- Uses statistical models to estimate geographical distribution
+- Provides data-driven insights into actual development activity locations
+
+Both methods work together to provide comprehensive geographical intelligence for software components.

--- a/protobuf/scanoss/api/geoprovenance/v2/scanoss-geoprovenance.proto
+++ b/protobuf/scanoss/api/geoprovenance/v2/scanoss-geoprovenance.proto
@@ -64,83 +64,230 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
  * Expose all of the SCANOSS Geo Provenance RPCs here
  */
 service GeoProvenance {
-  // Standard echo
+  // Standard health check endpoint to verify service availability and connectivity
   rpc Echo(scanoss.api.common.v2.EchoRequest) returns(scanoss.api.common.v2.EchoResponse) {
     option (google.api.http) = {
       post: "/v2/geoprovenance/echo"
       body: "*"
     };
   };
-  // Get component-level Geo Provenance based on contributor declared location
+
+  // [DEPRECATED] Get component-level Geo Provenance based on contributor declared location
+  // This method accepts PURL-based requests and is deprecated in favor of GetCountryContributorsByComponent
+  // which accepts ComponentRequest for better component identification
   rpc GetComponentContributors(scanoss.api.common.v2.PurlRequest) returns(ContributorResponse) {
+    option deprecated = true;
     option (google.api.http) = {
       post: "/v2/geoprovenance/countries"
       body: "*"
     };
   };
-  // Get component-level Geo Provenance based on contributor origin commit times
+
+  // Get component-level Geo Provenance based on contributor declared location
+  // This is the current method that accepts ComponentsRequest for enhanced component identification
+  // Replaces the deprecated GetComponentContributors method
+  rpc GetCountryContributorsByComponents(scanoss.api.common.v2.ComponentsRequest) returns(ComponentsContributorResponse) {
+    option (google.api.http) = {
+      post: "/v2/geoprovenance/countries/components"
+      body: "*"
+    };
+  };
+
+  // Get component-level Geo Provenance based on contributor declared location
+  // This is the current method that accepts ComponentRequest for enhanced component identification
+  // Replaces the deprecated GetComponentContributors method
+  rpc GetCountryContributorsByComponent(scanoss.api.common.v2.ComponentRequest) returns(ComponentContributorResponse) {
+    option (google.api.http) = {
+      get: "/v2/geoprovenance/countries/component"
+    };
+  };
+
+  // [DEPRECATED] Get component-level Geo Provenance based on contributor origin commit times
+  // This method accepts PURL-based requests and is deprecated in favor of GetOriginByComponent
+  // which accepts ComponentRequest for better component identification
   rpc GetComponentOrigin(scanoss.api.common.v2.PurlRequest) returns(OriginResponse) {
+    option deprecated = true;
     option (google.api.http) = {
       post: "/v2/geoprovenance/origin"
       body: "*"
     };
   };
+
+  // Get component-level Geo Provenance based on contributor origin commit times
+  // This is the current method that accepts ComponentsRequest for enhanced component identification
+  // Replaces the deprecated GetComponentOrigin method
+  rpc GetOriginByComponents(scanoss.api.common.v2.ComponentsRequest) returns(ComponentsOriginResponse) {
+    option (google.api.http) = {
+      post: "/v2/geoprovenance/origin/components"
+      body: "*"
+    };
+  };
+
+  // Get component-level Geo Provenance based on contributor origin commit times
+  // This is the current method that accepts ComponentRequest for enhanced component identification
+  // Replaces the deprecated GetComponentOrigin method
+  rpc GetOriginByComponent(scanoss.api.common.v2.ComponentRequest) returns(ComponentOriginResponse) {
+    option (google.api.http) = {
+      get: "/v2/geoprovenance/origin/component"
+    };
+  };
+}
+
+
+
+// Declared location information for the project
+message DeclaredLocation {
+  // Source type of the declared location (e.g., "owner" or "contributor")
+  string type = 1;
+  // Geographic location declared in the repository (Country/State/City/Province/Place)
+  string location = 2;
+}
+
+// SCANOSS curated provenance information about the project
+message CuratedLocation {
+  // Country name for the owner or contributor
+  string country = 1;
+  // Number of users or contributors from this specific country
+  int32 count = 2;
+}
+
+/**
+ * [DEPRECATED] Component level Provenance Response data (JSON payload)
+ * This message is deprecated. Use ComponentContributorResponse instead for better component handling.
+ * Contains geo-provenance information for components based on contributor declared locations.
+ */
+message ContributorResponse {
+  option deprecated = true;
+  // Information about a given Package URL (PURL)
+  message Purls {
+    // The Package URL string identifying the component
+    string purl = 1;
+    // List of locations declared in the component's repository
+    repeated DeclaredLocation declared_locations = 2 [json_name = "declared_locations"];
+    // List of SCANOSS curated locations based on analysis
+    repeated CuratedLocation curated_locations = 3 [json_name = "curated_locations"];
+  }
+  // Geo-provenance details for each requested component
+  repeated Purls purls = 1;
+  // Response status indicating success or failure of the request
+  scanoss.api.common.v2.StatusResponse status = 2;
+}
+
+// Information about a given component
+message ComponentLocationInfo {
+  // The Package URL string identifying the component
+  string purl = 1;
+  // List of locations declared in the component's repository
+  repeated DeclaredLocation declared_locations = 2 [json_name = "declared_locations"];
+  // List of SCANOSS curated locations based on analysis
+  repeated CuratedLocation curated_locations = 3 [json_name = "curated_locations"];
 }
 
 /**
  * Component level Provenance Response data (JSON payload)
+ * Contains geo-provenance information for components based on contributor declared locations.
+ * This is the current response format that replaces the deprecated ContributorResponse.
  */
-message ContributorResponse {
-  // Declared location for the project
-  message DeclaredLocation {
-    // Declared location could be either from the owner or a contributor
-    string type = 1;
-    // Country/State/City/Province/Place declared on the repo
-    string location = 2;
-  }
-  // Curated provenance information about the project
-  message CuratedLocation {
-    // Country for the owner or contributor
-    string country = 1;
-    // Occurrences for users or contributors of this specific country
-    int32 count = 2;
-  }
-  // Information about a given purl
+message ComponentsContributorResponse {
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+    json_schema: {
+      example: "{\"components_locations\":[{\"purl\":\"pkg:github/scanoss/engine@5.0.0\",\"declared_locations\":[{\"type\":\"owner\",\"location\":\"Barcelona, Spain\"},{\"type\":\"contributor\",\"location\":\"Berlin, Germany\"}],\"curated_locations\":[{\"country\":\"Spain\",\"count\":8},{\"country\":\"Germany\",\"count\":3},{\"country\":\"United States\",\"count\":2}]}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Geo-provenance successfully retrieved\"}}";
+    }
+  };
+  // Geo-provenance details for each requested component
+  repeated ComponentLocationInfo components_locations = 1  [json_name = "components_locations"];
+  // Response status indicating success or failure of the request
+  scanoss.api.common.v2.StatusResponse status = 2;
+}
+
+/**
+ * Component level Provenance Response data (JSON payload)
+ * Contains geo-provenance information for components based on contributor declared locations.
+ * This is the current response format that replaces the deprecated ContributorResponse.
+ */
+message ComponentContributorResponse {
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+    json_schema: {
+      example: "{\"component_location\":{\"purl\":\"pkg:github/scanoss/engine@5.0.0\",\"declared_locations\":[{\"type\":\"owner\",\"location\":\"Barcelona, Spain\"},{\"type\":\"contributor\",\"location\":\"Berlin, Germany\"}],\"curated_locations\":[{\"country\":\"Spain\",\"count\":8},{\"country\":\"Germany\",\"count\":3},{\"country\":\"United States\",\"count\":2}]},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Geo-provenance successfully retrieved\"}}";
+    }
+  };
+  // Geo-provenance details for each requested component
+  ComponentLocationInfo component_locations = 1  [json_name = "component_locations"];
+  // Response status indicating success or failure of the request
+  scanoss.api.common.v2.StatusResponse status = 2;
+}
+
+
+// Origin country details for geo-provenance analysis
+message Location {
+  // ISO country code (e.g., "US", "GB", "FR")
+  string name = 1;
+  // Percentage of developers from this country
+  float percentage = 2;
+}
+
+// Information about a component and its geographic origins
+message ComponentLocation {
+  // The Package URL string identifying the component
+  string purl = 1;
+  // The list of countries with contributors and their percentages
+  repeated Location locations = 2;
+}
+
+/**
+ * [DEPRECATED] Component level Origin Response data (JSON payload)
+ * This message is deprecated. Use ComponentOriginResponse instead for better component handling.
+ * Contains geo-provenance information based on contributor origin commit times.
+ */
+message OriginResponse {
+  option deprecated = true;
+  // Origin country details for geo-provenance analysis
+  // Information about the given Package URL (PURL)
   message Purls {
-    // The purl string
+    // The Package URL string identifying the component
     string purl = 1;
-    // List of locations declared on user repository
-    repeated DeclaredLocation declared_locations = 2;
-    // List of craft curated location
-    repeated CuratedLocation curated_locations = 3;
+    // The list of countries with contributors and their percentages
+    repeated Location locations = 2;
   }
-  // Provenance details
+  // Geo-provenance details for each requested component
   repeated Purls purls = 1;
-  // Response status
+  // Response status indicating success or failure of the request
+  scanoss.api.common.v2.StatusResponse status = 2;
+}
+
+
+/**
+ * Component level Origin Response data (JSON payload)
+ * Contains geo-provenance information based on contributor origin commit times.
+ * This is the current response format that replaces the deprecated OriginResponse.
+ * Provides enhanced component identification and location data.
+ */
+message ComponentsOriginResponse {
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+    json_schema: {
+      example: "{\"components_locations\":[{\"purl\":\"pkg:github/scanoss/engine@5.0.0\",\"locations\":[{\"name\":\"ES\",\"percentage\":65.5},{\"name\":\"DE\",\"percentage\":20.3},{\"name\":\"US\",\"percentage\":14.2}]}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Geo-provenance origin successfully retrieved\"}}";
+    }
+  };
+  // Geo-provenance details for each requested component
+  repeated ComponentLocation components_locations = 1 [json_name = "components_locations"];
+  // Response status indicating success or failure of the request
   scanoss.api.common.v2.StatusResponse status = 2;
 }
 
 /**
  * Component level Origin Response data (JSON payload)
+ * Contains geo-provenance information based on contributor origin commit times.
+ * This is the current response format that replaces the deprecated OriginResponse.
+ * Provides enhanced component identification and location data.
  */
-message OriginResponse {
-    // Origin country details
-    message Location {  
-        // ISO Country code 
-        string name = 1;
-        // Percentage of developers
-        float percentage = 2; 
-
+message ComponentOriginResponse {
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
+    json_schema: {
+      example: "{\"component_locations\": {\"purl\":\"pkg:github/scanoss/engine@5.0.0\",\"locations\":[{\"name\":\"ES\",\"percentage\":65.5},{\"name\":\"DE\",\"percentage\":20.3},{\"name\":\"US\",\"percentage\":14.2}]},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Geo-provenance origin successfully retrieved\"}}";
     }
-    // Information about the given PURL
-    message Purls {
-        // The purl string
-        string purl = 1;
-        // The list of countries with contributors
-        repeated Location locations = 2;  
-    }
-  // Geo Provenance details
-  repeated Purls purls = 1;
-  // Response status
+  };
+  // Geo-provenance details for each requested component
+  ComponentLocation component_locations = 1 [json_name = "component_locations"];
+  // Response status indicating success or failure of the request
   scanoss.api.common.v2.StatusResponse status = 2;
 }

--- a/protobuf/scanoss/api/geoprovenance/v2/scanoss-geoprovenance.swagger.json
+++ b/protobuf/scanoss/api/geoprovenance/v2/scanoss-geoprovenance.swagger.json
@@ -26,7 +26,7 @@
   "paths": {
     "/v2/geoprovenance/countries": {
       "post": {
-        "summary": "Get component-level Geo Provenance based on contributor declared location",
+        "summary": "[DEPRECATED] Get component-level Geo Provenance based on contributor declared location\nThis method accepts PURL-based requests and is deprecated in favor of GetCountryContributorsByComponent\nwhich accepts ComponentRequest for better component identification",
         "operationId": "GeoProvenance_GetComponentContributors",
         "responses": {
           "200": {
@@ -65,9 +65,96 @@
         ]
       }
     },
+    "/v2/geoprovenance/countries/component": {
+      "get": {
+        "summary": "Get component-level Geo Provenance based on contributor declared location\nThis is the current method that accepts ComponentRequest for enhanced component identification\nReplaces the deprecated GetComponentContributors method",
+        "operationId": "GeoProvenance_GetCountryContributorsByComponent",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v2ComponentContributorResponse"
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "purl",
+            "description": "Package URL identifying the component to analyze.",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "requirement",
+            "description": "Version constraint for component resolution when PURL lacks explicit version.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "GeoProvenance"
+        ]
+      }
+    },
+    "/v2/geoprovenance/countries/components": {
+      "post": {
+        "summary": "Get component-level Geo Provenance based on contributor declared location\nThis is the current method that accepts ComponentsRequest for enhanced component identification\nReplaces the deprecated GetComponentContributors method",
+        "operationId": "GeoProvenance_GetCountryContributorsByComponents",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v2ComponentsContributorResponse"
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "Represents a list of software component to be analyzed by SCANOSS API services.\nAllows analysis of multiple software components in a single API call, improving performance over individual requests.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v2ComponentsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "GeoProvenance"
+        ]
+      }
+    },
     "/v2/geoprovenance/echo": {
       "post": {
-        "summary": "Standard echo",
+        "summary": "Standard health check endpoint to verify service availability and connectivity",
         "operationId": "GeoProvenance_Echo",
         "responses": {
           "200": {
@@ -108,7 +195,7 @@
     },
     "/v2/geoprovenance/origin": {
       "post": {
-        "summary": "Get component-level Geo Provenance based on contributor origin commit times",
+        "summary": "[DEPRECATED] Get component-level Geo Provenance based on contributor origin commit times\nThis method accepts PURL-based requests and is deprecated in favor of GetOriginByComponent\nwhich accepts ComponentRequest for better component identification",
         "operationId": "GeoProvenance_GetComponentOrigin",
         "responses": {
           "200": {
@@ -146,37 +233,110 @@
           "GeoProvenance"
         ]
       }
+    },
+    "/v2/geoprovenance/origin/component": {
+      "get": {
+        "summary": "Get component-level Geo Provenance based on contributor origin commit times\nThis is the current method that accepts ComponentRequest for enhanced component identification\nReplaces the deprecated GetComponentOrigin method",
+        "operationId": "GeoProvenance_GetOriginByComponent",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v2ComponentOriginResponse"
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "purl",
+            "description": "Package URL identifying the component to analyze.",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "requirement",
+            "description": "Version constraint for component resolution when PURL lacks explicit version.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "GeoProvenance"
+        ]
+      }
+    },
+    "/v2/geoprovenance/origin/components": {
+      "post": {
+        "summary": "Get component-level Geo Provenance based on contributor origin commit times\nThis is the current method that accepts ComponentsRequest for enhanced component identification\nReplaces the deprecated GetComponentOrigin method",
+        "operationId": "GeoProvenance_GetOriginByComponents",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v2ComponentsOriginResponse"
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "Represents a list of software component to be analyzed by SCANOSS API services.\nAllows analysis of multiple software components in a single API call, improving performance over individual requests.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v2ComponentsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "GeoProvenance"
+        ]
+      }
     }
   },
   "definitions": {
-    "ContributorResponseCuratedLocation": {
+    "geoprovenancev2Location": {
       "type": "object",
       "properties": {
-        "country": {
+        "name": {
           "type": "string",
-          "title": "Country for the owner or contributor"
+          "title": "ISO country code (e.g., \"US\", \"GB\", \"FR\")"
         },
-        "count": {
-          "type": "integer",
-          "format": "int32",
-          "title": "Occurrences for users or contributors of this specific country"
+        "percentage": {
+          "type": "number",
+          "format": "float",
+          "title": "Percentage of developers from this country"
         }
       },
-      "title": "Curated provenance information about the project"
-    },
-    "ContributorResponseDeclaredLocation": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "title": "Declared location could be either from the owner or a contributor"
-        },
-        "location": {
-          "type": "string",
-          "title": "Country/State/City/Province/Place declared on the repo"
-        }
-      },
-      "title": "Declared location for the project"
+      "title": "Origin country details for geo-provenance analysis"
     },
     "protobufAny": {
       "type": "object",
@@ -206,6 +366,277 @@
         }
       }
     },
+    "v2ComponentContributorResponse": {
+      "type": "object",
+      "example": {
+        "component_location": {
+          "purl": "pkg:github/scanoss/engine@5.0.0",
+          "declared_locations": [
+            {
+              "type": "owner",
+              "location": "Barcelona, Spain"
+            },
+            {
+              "type": "contributor",
+              "location": "Berlin, Germany"
+            }
+          ],
+          "curated_locations": [
+            {
+              "country": "Spain",
+              "count": 8
+            },
+            {
+              "country": "Germany",
+              "count": 3
+            },
+            {
+              "country": "United States",
+              "count": 2
+            }
+          ]
+        },
+        "status": {
+          "status": "SUCCESS",
+          "message": "Geo-provenance successfully retrieved"
+        }
+      },
+      "properties": {
+        "component_locations": {
+          "$ref": "#/definitions/v2ComponentLocationInfo",
+          "title": "Geo-provenance details for each requested component"
+        },
+        "status": {
+          "$ref": "#/definitions/v2StatusResponse",
+          "title": "Response status indicating success or failure of the request"
+        }
+      },
+      "description": "*\nComponent level Provenance Response data (JSON payload)\nContains geo-provenance information for components based on contributor declared locations.\nThis is the current response format that replaces the deprecated ContributorResponse."
+    },
+    "v2ComponentLocation": {
+      "type": "object",
+      "properties": {
+        "purl": {
+          "type": "string",
+          "title": "The Package URL string identifying the component"
+        },
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/geoprovenancev2Location"
+          },
+          "title": "The list of countries with contributors and their percentages"
+        }
+      },
+      "title": "Information about a component and its geographic origins"
+    },
+    "v2ComponentLocationInfo": {
+      "type": "object",
+      "properties": {
+        "purl": {
+          "type": "string",
+          "title": "The Package URL string identifying the component"
+        },
+        "declared_locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v2DeclaredLocation"
+          },
+          "title": "List of locations declared in the component's repository"
+        },
+        "curated_locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v2CuratedLocation"
+          },
+          "title": "List of SCANOSS curated locations based on analysis"
+        }
+      },
+      "title": "Information about a given component"
+    },
+    "v2ComponentOriginResponse": {
+      "type": "object",
+      "example": {
+        "component_locations": {
+          "purl": "pkg:github/scanoss/engine@5.0.0",
+          "locations": [
+            {
+              "name": "ES",
+              "percentage": 65.5
+            },
+            {
+              "name": "DE",
+              "percentage": 20.3
+            },
+            {
+              "name": "US",
+              "percentage": 14.2
+            }
+          ]
+        },
+        "status": {
+          "status": "SUCCESS",
+          "message": "Geo-provenance origin successfully retrieved"
+        }
+      },
+      "properties": {
+        "component_locations": {
+          "$ref": "#/definitions/v2ComponentLocation",
+          "title": "Geo-provenance details for each requested component"
+        },
+        "status": {
+          "$ref": "#/definitions/v2StatusResponse",
+          "title": "Response status indicating success or failure of the request"
+        }
+      },
+      "description": "*\nComponent level Origin Response data (JSON payload)\nContains geo-provenance information based on contributor origin commit times.\nThis is the current response format that replaces the deprecated OriginResponse.\nProvides enhanced component identification and location data."
+    },
+    "v2ComponentRequest": {
+      "type": "object",
+      "example": {
+        "purl": "pkg:github/scanoss/engine@1.0.0"
+      },
+      "properties": {
+        "purl": {
+          "type": "string",
+          "description": "Package URL identifying the component to analyze."
+        },
+        "requirement": {
+          "type": "string",
+          "description": "Version constraint for component resolution when PURL lacks explicit version."
+        }
+      },
+      "description": "Represents a software component to be analyzed by SCANOSS API services.\nCombines a Package URL for component identification with optional version constraints for resolution.",
+      "required": [
+        "purl"
+      ]
+    },
+    "v2ComponentsContributorResponse": {
+      "type": "object",
+      "example": {
+        "components_locations": [
+          {
+            "purl": "pkg:github/scanoss/engine@5.0.0",
+            "declared_locations": [
+              {
+                "type": "owner",
+                "location": "Barcelona, Spain"
+              },
+              {
+                "type": "contributor",
+                "location": "Berlin, Germany"
+              }
+            ],
+            "curated_locations": [
+              {
+                "country": "Spain",
+                "count": 8
+              },
+              {
+                "country": "Germany",
+                "count": 3
+              },
+              {
+                "country": "United States",
+                "count": 2
+              }
+            ]
+          }
+        ],
+        "status": {
+          "status": "SUCCESS",
+          "message": "Geo-provenance successfully retrieved"
+        }
+      },
+      "properties": {
+        "components_locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v2ComponentLocationInfo"
+          },
+          "title": "Geo-provenance details for each requested component"
+        },
+        "status": {
+          "$ref": "#/definitions/v2StatusResponse",
+          "title": "Response status indicating success or failure of the request"
+        }
+      },
+      "description": "*\nComponent level Provenance Response data (JSON payload)\nContains geo-provenance information for components based on contributor declared locations.\nThis is the current response format that replaces the deprecated ContributorResponse."
+    },
+    "v2ComponentsOriginResponse": {
+      "type": "object",
+      "example": {
+        "components_locations": [
+          {
+            "purl": "pkg:github/scanoss/engine@5.0.0",
+            "locations": [
+              {
+                "name": "ES",
+                "percentage": 65.5
+              },
+              {
+                "name": "DE",
+                "percentage": 20.3
+              },
+              {
+                "name": "US",
+                "percentage": 14.2
+              }
+            ]
+          }
+        ],
+        "status": {
+          "status": "SUCCESS",
+          "message": "Geo-provenance origin successfully retrieved"
+        }
+      },
+      "properties": {
+        "components_locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v2ComponentLocation"
+          },
+          "title": "Geo-provenance details for each requested component"
+        },
+        "status": {
+          "$ref": "#/definitions/v2StatusResponse",
+          "title": "Response status indicating success or failure of the request"
+        }
+      },
+      "description": "*\nComponent level Origin Response data (JSON payload)\nContains geo-provenance information based on contributor origin commit times.\nThis is the current response format that replaces the deprecated OriginResponse.\nProvides enhanced component identification and location data."
+    },
+    "v2ComponentsRequest": {
+      "type": "object",
+      "example": {
+        "components": [
+          {
+            "purl": "pkg:github/scanoss/engine@1.0.0"
+          },
+          {
+            "purl": "pkg:github/scanoss/scanoss.py@v1.30.0"
+          }
+        ]
+      },
+      "properties": {
+        "components": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v2ComponentRequest"
+          },
+          "title": "Array of component requests to analyze"
+        }
+      },
+      "description": "Represents a list of software component to be analyzed by SCANOSS API services.\nAllows analysis of multiple software components in a single API call, improving performance over individual requests.",
+      "required": [
+        "components"
+      ]
+    },
     "v2ContributorResponse": {
       "type": "object",
       "properties": {
@@ -215,40 +646,69 @@
             "type": "object",
             "$ref": "#/definitions/v2ContributorResponsePurls"
           },
-          "title": "Provenance details"
+          "title": "Geo-provenance details for each requested component"
         },
         "status": {
           "$ref": "#/definitions/v2StatusResponse",
-          "title": "Response status"
+          "title": "Response status indicating success or failure of the request"
         }
       },
-      "title": "*\nComponent level Provenance Response data (JSON payload)"
+      "description": "*\n[DEPRECATED] Component level Provenance Response data (JSON payload)\nThis message is deprecated. Use ComponentContributorResponse instead for better component handling.\nContains geo-provenance information for components based on contributor declared locations."
     },
     "v2ContributorResponsePurls": {
       "type": "object",
       "properties": {
         "purl": {
           "type": "string",
-          "title": "The purl string"
+          "title": "The Package URL string identifying the component"
         },
         "declared_locations": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/ContributorResponseDeclaredLocation"
+            "$ref": "#/definitions/v2DeclaredLocation"
           },
-          "title": "List of locations declared on user repository"
+          "title": "List of locations declared in the component's repository"
         },
         "curated_locations": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/ContributorResponseCuratedLocation"
+            "$ref": "#/definitions/v2CuratedLocation"
           },
-          "title": "List of craft curated location"
+          "title": "List of SCANOSS curated locations based on analysis"
         }
       },
-      "title": "Information about a given purl"
+      "title": "Information about a given Package URL (PURL)"
+    },
+    "v2CuratedLocation": {
+      "type": "object",
+      "properties": {
+        "country": {
+          "type": "string",
+          "title": "Country name for the owner or contributor"
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Number of users or contributors from this specific country"
+        }
+      },
+      "title": "SCANOSS curated provenance information about the project"
+    },
+    "v2DeclaredLocation": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "Source type of the declared location (e.g., \"owner\" or \"contributor\")"
+        },
+        "location": {
+          "type": "string",
+          "title": "Geographic location declared in the repository (Country/State/City/Province/Place)"
+        }
+      },
+      "title": "Declared location information for the project"
     },
     "v2EchoRequest": {
       "type": "object",
@@ -277,47 +737,32 @@
             "type": "object",
             "$ref": "#/definitions/v2OriginResponsePurls"
           },
-          "title": "Geo Provenance details"
+          "title": "Geo-provenance details for each requested component"
         },
         "status": {
           "$ref": "#/definitions/v2StatusResponse",
-          "title": "Response status"
+          "title": "Response status indicating success or failure of the request"
         }
       },
-      "title": "*\nComponent level Origin Response data (JSON payload)"
-    },
-    "v2OriginResponseLocation": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "title": "ISO Country code"
-        },
-        "percentage": {
-          "type": "number",
-          "format": "float",
-          "title": "Percentage of developers"
-        }
-      },
-      "title": "Origin country details"
+      "description": "*\n[DEPRECATED] Component level Origin Response data (JSON payload)\nThis message is deprecated. Use ComponentOriginResponse instead for better component handling.\nContains geo-provenance information based on contributor origin commit times."
     },
     "v2OriginResponsePurls": {
       "type": "object",
       "properties": {
         "purl": {
           "type": "string",
-          "title": "The purl string"
+          "title": "The Package URL string identifying the component"
         },
         "locations": {
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v2OriginResponseLocation"
+            "$ref": "#/definitions/geoprovenancev2Location"
           },
-          "title": "The list of countries with contributors"
+          "title": "The list of countries with contributors and their percentages"
         }
       },
-      "title": "Information about the given PURL"
+      "title": "Origin country details for geo-provenance analysis\nInformation about the given Package URL (PURL)"
     },
     "v2PurlRequest": {
       "type": "object",

--- a/protobuf/scanoss/api/scanning/v2/scanoss-scanning.swagger.json
+++ b/protobuf/scanoss/api/scanning/v2/scanoss-scanning.swagger.json
@@ -281,12 +281,12 @@
           "format": "int32",
           "title": "Maximum number of results to query"
         },
-        "recursiveThreshold": {
+        "recursive_threshold": {
           "type": "number",
           "format": "float",
           "title": "Minimum score threshold to consider a match"
         },
-        "minAcceptedScore": {
+        "min_accepted_score": {
           "type": "number",
           "format": "float",
           "title": "Minimum score threshold to accept a match"


### PR DESCRIPTION
## What's Changed

### Added
- Added gRPC `GetCountryContributorsByComponents` and REST endpoint POST `/v2/geoprovenance/countries/components`
- Added gRPC `GetOriginByComponents` and REST endpoint POST `/v2/geoprovenance/origin/components`
- Added comprehensive documentation to geo-provenance protobuf service
- Added geo-provenance API documentation (README.md)
- Added JSON schema examples to geo-provenance response messages
- Added new response message types `ComponentsContributorResponse` and `ComponentsOriginResponse` for enhanced component handling
### Changed
- Enhanced geo-provenance protobuf definitions with comprehensive service and message documentation
- Updated OpenAPI schema with realistic JSON response examples for geo-provenance endpoints
- Enhanced field documentation across all geo-provenance message types
### Deprecated
- Deprecated gRPC `GetComponentContributors` method (use `GetCountryContributorsByComponents` instead)
- Deprecated gRPC `GetComponentOrigin` method (use `GetOriginByComponents` instead)
- Deprecated `ContributorResponse` and `OriginResponse` message types (use new component-based response types instead)
