### PR TITLE
chore(licenses):SP-4313 change error_code field type from ErrorCode e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.35.1] - 2026-04-15
+
+## [0.36.0] - 2026-04-15
 ### Changed
 - Changed `error_code` field type from `common.v2.ErrorCode` enum to `string` in `ComponentLicenseInfo` message
 
@@ -274,7 +275,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Vulnerabilities
 - Added REST endpoint support for each service also
 
-[0.35.1]: https://github.com/scanoss/papi/compare/v0.35.0...v0.35.1
+[0.36.0]: https://github.com/scanoss/papi/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/scanoss/papi/compare/v0.34.1...v0.35.0
 [0.34.1]: https://github.com/scanoss/papi/compare/v0.34.0...v0.34.1
 [0.34.0]: https://github.com/scanoss/papi/compare/v0.33.0...v0.34.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.35.1] - 2026-04-15
+### Changed
+- Changed `error_code` field type from `common.v2.ErrorCode` enum to `string` in `ComponentLicenseInfo` message
 
 ## [0.35.0] - 2026-04-13
 ### Added
@@ -271,6 +274,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Vulnerabilities
 - Added REST endpoint support for each service also
 
+[0.35.1]: https://github.com/scanoss/papi/compare/v0.35.0...v0.35.1
 [0.35.0]: https://github.com/scanoss/papi/compare/v0.34.1...v0.35.0
 [0.34.1]: https://github.com/scanoss/papi/compare/v0.34.0...v0.34.1
 [0.34.0]: https://github.com/scanoss/papi/compare/v0.33.0...v0.34.0

--- a/api/licensesv2/scanoss-licenses.pb.go
+++ b/api/licensesv2/scanoss-licenses.pb.go
@@ -787,10 +787,10 @@ type ComponentLicenseInfo struct {
 	Licenses []*LicenseInfo `protobuf:"bytes,5,rep,name=licenses,proto3" json:"licenses,omitempty"`
 	// Optional error message describing what went wrong during component processing
 	ErrorMessage *string `protobuf:"bytes,8,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	// Optional error code indicating the type of error encountered
-	ErrorCode *string `protobuf:"bytes,9,opt,name=error_code,proto3,oneof" json:"error_code,omitempty"`
 	// Component URL
-	Url           string `protobuf:"bytes,10,opt,name=url,proto3" json:"url,omitempty"`
+	Url string `protobuf:"bytes,10,opt,name=url,proto3" json:"url,omitempty"`
+	// Optional error code indicating the type of error encountered (moved from position 9).
+	ErrorCode     *string `protobuf:"bytes,11,opt,name=error_code,proto3,oneof" json:"error_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -867,16 +867,16 @@ func (x *ComponentLicenseInfo) GetErrorMessage() string {
 	return ""
 }
 
-func (x *ComponentLicenseInfo) GetErrorCode() string {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentLicenseInfo) GetUrl() string {
+	if x != nil {
+		return x.Url
 	}
 	return ""
 }
 
-func (x *ComponentLicenseInfo) GetUrl() string {
-	if x != nil {
-		return x.Url
+func (x *ComponentLicenseInfo) GetErrorCode() string {
+	if x != nil && x.ErrorCode != nil {
+		return *x.ErrorCode
 	}
 	return ""
 }
@@ -1219,12 +1219,12 @@ const file_scanoss_api_licenses_v2_scanoss_licenses_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x12\x1c\n" +
 	"\tstatement\x18\x04 \x01(\tR\tstatement\x12@\n" +
 	"\blicenses\x18\x05 \x03(\v2$.scanoss.api.licenses.v2.LicenseInfoR\blicenses\x12)\n" +
-	"\rerror_message\x18\b \x01(\tH\x00R\rerror_message\x88\x01\x01\x12#\n" +
-	"\n" +
-	"error_code\x18\t \x01(\tH\x01R\n" +
-	"error_code\x88\x01\x01\x12\x10\n" +
+	"\rerror_message\x18\b \x01(\tH\x00R\rerror_message\x88\x01\x01\x12\x10\n" +
 	"\x03url\x18\n" +
-	" \x01(\tR\x03urlB\x10\n" +
+	" \x01(\tR\x03url\x12#\n" +
+	"\n" +
+	"error_code\x18\v \x01(\tH\x01R\n" +
+	"error_code\x88\x01\x01B\x10\n" +
 	"\x0e_error_messageB\r\n" +
 	"\v_error_code*l\n" +
 	"\vLicenseType\x12\v\n" +

--- a/api/licensesv2/scanoss-licenses.pb.go
+++ b/api/licensesv2/scanoss-licenses.pb.go
@@ -788,7 +788,7 @@ type ComponentLicenseInfo struct {
 	// Optional error message describing what went wrong during component processing
 	ErrorMessage *string `protobuf:"bytes,8,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
 	// Optional error code indicating the type of error encountered
-	ErrorCode *commonv2.ErrorCode `protobuf:"varint,9,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	ErrorCode *string `protobuf:"bytes,9,opt,name=error_code,proto3,oneof" json:"error_code,omitempty"`
 	// Component URL
 	Url           string `protobuf:"bytes,10,opt,name=url,proto3" json:"url,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -867,11 +867,11 @@ func (x *ComponentLicenseInfo) GetErrorMessage() string {
 	return ""
 }
 
-func (x *ComponentLicenseInfo) GetErrorCode() commonv2.ErrorCode {
+func (x *ComponentLicenseInfo) GetErrorCode() string {
 	if x != nil && x.ErrorCode != nil {
 		return *x.ErrorCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 func (x *ComponentLicenseInfo) GetUrl() string {
@@ -1212,16 +1212,16 @@ const file_scanoss_api_licenses_v2_scanoss_licenses_proto_rawDesc = "" +
 	"\x04spdx\x18\x03 \x01(\v2\x1d.scanoss.api.licenses.v2.SPDXR\x04spdx\x124\n" +
 	"\x05osadl\x18\x04 \x01(\v2\x1e.scanoss.api.licenses.v2.OSADLR\x05osadl\" \n" +
 	"\x0eLicenseRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\"\xeb\x02\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\xc9\x02\n" +
 	"\x14ComponentLicenseInfo\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12 \n" +
 	"\vrequirement\x18\x02 \x01(\tR\vrequirement\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x12\x1c\n" +
 	"\tstatement\x18\x04 \x01(\tR\tstatement\x12@\n" +
 	"\blicenses\x18\x05 \x03(\v2$.scanoss.api.licenses.v2.LicenseInfoR\blicenses\x12)\n" +
-	"\rerror_message\x18\b \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\rerror_message\x18\b \x01(\tH\x00R\rerror_message\x88\x01\x01\x12#\n" +
 	"\n" +
-	"error_code\x18\t \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
+	"error_code\x18\t \x01(\tH\x01R\n" +
 	"error_code\x88\x01\x01\x12\x10\n" +
 	"\x03url\x18\n" +
 	" \x01(\tR\x03urlB\x10\n" +
@@ -1276,11 +1276,10 @@ var file_scanoss_api_licenses_v2_scanoss_licenses_proto_goTypes = []any{
 	(*SPDX_SPDXException)(nil),         // 12: scanoss.api.licenses.v2.SPDX.SPDXException
 	(*OSADL_OSADLUseCase)(nil),         // 13: scanoss.api.licenses.v2.OSADL.OSADLUseCase
 	(*commonv2.StatusResponse)(nil),    // 14: scanoss.api.common.v2.StatusResponse
-	(commonv2.ErrorCode)(0),            // 15: scanoss.api.common.v2.ErrorCode
-	(*commonv2.EchoRequest)(nil),       // 16: scanoss.api.common.v2.EchoRequest
-	(*commonv2.ComponentRequest)(nil),  // 17: scanoss.api.common.v2.ComponentRequest
-	(*commonv2.ComponentsRequest)(nil), // 18: scanoss.api.common.v2.ComponentsRequest
-	(*commonv2.EchoResponse)(nil),      // 19: scanoss.api.common.v2.EchoResponse
+	(*commonv2.EchoRequest)(nil),       // 15: scanoss.api.common.v2.EchoRequest
+	(*commonv2.ComponentRequest)(nil),  // 16: scanoss.api.common.v2.ComponentRequest
+	(*commonv2.ComponentsRequest)(nil), // 17: scanoss.api.common.v2.ComponentsRequest
+	(*commonv2.EchoResponse)(nil),      // 18: scanoss.api.common.v2.EchoResponse
 }
 var file_scanoss_api_licenses_v2_scanoss_licenses_proto_depIdxs = []int32{
 	10, // 0: scanoss.api.licenses.v2.ComponentLicenseResponse.component:type_name -> scanoss.api.licenses.v2.ComponentLicenseInfo
@@ -1298,22 +1297,21 @@ var file_scanoss_api_licenses_v2_scanoss_licenses_proto_depIdxs = []int32{
 	5,  // 12: scanoss.api.licenses.v2.LicenseDetails.spdx:type_name -> scanoss.api.licenses.v2.SPDX
 	6,  // 13: scanoss.api.licenses.v2.LicenseDetails.osadl:type_name -> scanoss.api.licenses.v2.OSADL
 	7,  // 14: scanoss.api.licenses.v2.ComponentLicenseInfo.licenses:type_name -> scanoss.api.licenses.v2.LicenseInfo
-	15, // 15: scanoss.api.licenses.v2.ComponentLicenseInfo.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	16, // 16: scanoss.api.licenses.v2.License.Echo:input_type -> scanoss.api.common.v2.EchoRequest
-	17, // 17: scanoss.api.licenses.v2.License.GetComponentLicenses:input_type -> scanoss.api.common.v2.ComponentRequest
-	18, // 18: scanoss.api.licenses.v2.License.GetComponentsLicenses:input_type -> scanoss.api.common.v2.ComponentsRequest
-	9,  // 19: scanoss.api.licenses.v2.License.GetDetails:input_type -> scanoss.api.licenses.v2.LicenseRequest
-	9,  // 20: scanoss.api.licenses.v2.License.GetObligations:input_type -> scanoss.api.licenses.v2.LicenseRequest
-	19, // 21: scanoss.api.licenses.v2.License.Echo:output_type -> scanoss.api.common.v2.EchoResponse
-	1,  // 22: scanoss.api.licenses.v2.License.GetComponentLicenses:output_type -> scanoss.api.licenses.v2.ComponentLicenseResponse
-	2,  // 23: scanoss.api.licenses.v2.License.GetComponentsLicenses:output_type -> scanoss.api.licenses.v2.ComponentsLicenseResponse
-	3,  // 24: scanoss.api.licenses.v2.License.GetDetails:output_type -> scanoss.api.licenses.v2.LicenseDetailsResponse
-	4,  // 25: scanoss.api.licenses.v2.License.GetObligations:output_type -> scanoss.api.licenses.v2.ObligationsResponse
-	21, // [21:26] is the sub-list for method output_type
-	16, // [16:21] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	15, // 15: scanoss.api.licenses.v2.License.Echo:input_type -> scanoss.api.common.v2.EchoRequest
+	16, // 16: scanoss.api.licenses.v2.License.GetComponentLicenses:input_type -> scanoss.api.common.v2.ComponentRequest
+	17, // 17: scanoss.api.licenses.v2.License.GetComponentsLicenses:input_type -> scanoss.api.common.v2.ComponentsRequest
+	9,  // 18: scanoss.api.licenses.v2.License.GetDetails:input_type -> scanoss.api.licenses.v2.LicenseRequest
+	9,  // 19: scanoss.api.licenses.v2.License.GetObligations:input_type -> scanoss.api.licenses.v2.LicenseRequest
+	18, // 20: scanoss.api.licenses.v2.License.Echo:output_type -> scanoss.api.common.v2.EchoResponse
+	1,  // 21: scanoss.api.licenses.v2.License.GetComponentLicenses:output_type -> scanoss.api.licenses.v2.ComponentLicenseResponse
+	2,  // 22: scanoss.api.licenses.v2.License.GetComponentsLicenses:output_type -> scanoss.api.licenses.v2.ComponentsLicenseResponse
+	3,  // 23: scanoss.api.licenses.v2.License.GetDetails:output_type -> scanoss.api.licenses.v2.LicenseDetailsResponse
+	4,  // 24: scanoss.api.licenses.v2.License.GetObligations:output_type -> scanoss.api.licenses.v2.ObligationsResponse
+	20, // [20:25] is the sub-list for method output_type
+	15, // [15:20] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_scanoss_api_licenses_v2_scanoss_licenses_proto_init() }

--- a/protobuf/scanoss/api/licenses/v2/scanoss-licenses.proto
+++ b/protobuf/scanoss/api/licenses/v2/scanoss-licenses.proto
@@ -382,7 +382,7 @@ message ComponentLicenseInfo {
   // Optional error message describing what went wrong during component processing
   optional string error_message = 8 [json_name = "error_message"];
   // Optional error code indicating the type of error encountered
-  optional common.v2.ErrorCode error_code = 9  [json_name = "error_code"];
+  optional string error_code = 9  [json_name = "error_code"];
   // Component URL
   string url = 10 [json_name = "url"];
 }

--- a/protobuf/scanoss/api/licenses/v2/scanoss-licenses.proto
+++ b/protobuf/scanoss/api/licenses/v2/scanoss-licenses.proto
@@ -381,8 +381,8 @@ message ComponentLicenseInfo {
   repeated LicenseInfo licenses = 5;
   // Optional error message describing what went wrong during component processing
   optional string error_message = 8 [json_name = "error_message"];
-  // Optional error code indicating the type of error encountered
-  optional string error_code = 9  [json_name = "error_code"];
   // Component URL
   string url = 10 [json_name = "url"];
+  // Optional error code indicating the type of error encountered (moved from position 9).
+  optional string error_code = 11 [json_name = "error_code"];
 }

--- a/protobuf/scanoss/api/licenses/v2/scanoss-licenses.swagger.json
+++ b/protobuf/scanoss/api/licenses/v2/scanoss-licenses.swagger.json
@@ -370,7 +370,7 @@
           "title": "Optional error message describing what went wrong during component processing"
         },
         "error_code": {
-          "$ref": "#/definitions/v2ErrorCode",
+          "type": "string",
           "title": "Optional error code indicating the type of error encountered"
         },
         "url": {
@@ -533,19 +533,6 @@
         }
       },
       "description": "Echo Message Response."
-    },
-    "v2ErrorCode": {
-      "type": "string",
-      "enum": [
-        "INVALID_PURL",
-        "COMPONENT_NOT_FOUND",
-        "NO_INFO",
-        "INVALID_SEMVER",
-        "VERSION_NOT_FOUND",
-        "TOO_MANY_CONTRIBUTORS"
-      ],
-      "default": "INVALID_PURL",
-      "description": "Error code enum for component analysis operations.\nRepresents the various error conditions that can occur during component processing and validation.\n\n - INVALID_PURL: The provided Package URL (PURL) is invalid or malformed\n - COMPONENT_NOT_FOUND: The requested component could not be found in the database\n - NO_INFO: No information is available for the requested component\n - INVALID_SEMVER: The provided semantic version (SemVer) is invalid or malformed\n - VERSION_NOT_FOUND: Component version not found\n - TOO_MANY_CONTRIBUTORS: Too many contributors for a component. Used by Geoprovenance service"
     },
     "v2LicenseDetails": {
       "type": "object",

--- a/protobuf/scanoss/api/licenses/v2/scanoss-licenses.swagger.json
+++ b/protobuf/scanoss/api/licenses/v2/scanoss-licenses.swagger.json
@@ -369,13 +369,13 @@
           "type": "string",
           "title": "Optional error message describing what went wrong during component processing"
         },
-        "error_code": {
-          "type": "string",
-          "title": "Optional error code indicating the type of error encountered"
-        },
         "url": {
           "type": "string",
           "title": "Component URL"
+        },
+        "error_code": {
+          "type": "string",
+          "description": "Optional error code indicating the type of error encountered (moved from position 9)."
         }
       },
       "description": "License information for a specific component identified by PURL and version."


### PR DESCRIPTION
…num to string in ComponentLicenseInfo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changed**
  * Modified `error_code` field in license component information from enumerated type to string format. This change updates the API schema to provide greater flexibility in error code handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->