### PR TITLE
 chore(licenses):SP-4315 replace error_message/error_code with info_m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-04-16
+### Added
+- Added `info_message` and `info_code` fields to `ComponentLicenseInfo` message as the definitive fields for reporting the outcome of processing each component
+### Removed
+- **Breaking change:** Removed `error_message` and `error_code` fields from `ComponentLicenseInfo` message. Clients must migrate to `info_message`/`info_code`
+
 ## [0.36.0] - 2026-04-15
 ### Changed
 - Changed `error_code` field type from `common.v2.ErrorCode` enum to `string` in `ComponentLicenseInfo` message
@@ -275,6 +281,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Vulnerabilities
 - Added REST endpoint support for each service also
 
+[0.37.0]: https://github.com/scanoss/papi/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/scanoss/papi/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/scanoss/papi/compare/v0.34.1...v0.35.0
 [0.34.1]: https://github.com/scanoss/papi/compare/v0.34.0...v0.34.1

--- a/api/licensesv2/scanoss-licenses.pb.go
+++ b/api/licensesv2/scanoss-licenses.pb.go
@@ -785,12 +785,22 @@ type ComponentLicenseInfo struct {
 	Statement string `protobuf:"bytes,4,opt,name=statement,proto3" json:"statement,omitempty"`
 	// Individual licenses identified in the component
 	Licenses []*LicenseInfo `protobuf:"bytes,5,rep,name=licenses,proto3" json:"licenses,omitempty"`
-	// Optional error message describing what went wrong during component processing
-	ErrorMessage *string `protobuf:"bytes,8,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
 	// Component URL
 	Url string `protobuf:"bytes,10,opt,name=url,proto3" json:"url,omitempty"`
-	// Optional error code indicating the type of error encountered (moved from position 9).
-	ErrorCode     *string `protobuf:"bytes,11,opt,name=error_code,proto3,oneof" json:"error_code,omitempty"`
+	// Status message describing the outcome of processing this component.
+	// Replaces the removed `error_message` field (position 8).
+	InfoMessage *string `protobuf:"bytes,12,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component. Always populated.
+	// Replaces the removed `error_code` field (position 11).
+	//
+	// Possible values:
+	//   - "SUCCESS":             Component processed successfully.
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No license information is available for the requested component.
+	//   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+	//   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+	InfoCode      *string `protobuf:"bytes,13,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -860,13 +870,6 @@ func (x *ComponentLicenseInfo) GetLicenses() []*LicenseInfo {
 	return nil
 }
 
-func (x *ComponentLicenseInfo) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
-	}
-	return ""
-}
-
 func (x *ComponentLicenseInfo) GetUrl() string {
 	if x != nil {
 		return x.Url
@@ -874,9 +877,16 @@ func (x *ComponentLicenseInfo) GetUrl() string {
 	return ""
 }
 
-func (x *ComponentLicenseInfo) GetErrorCode() string {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentLicenseInfo) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
+	}
+	return ""
+}
+
+func (x *ComponentLicenseInfo) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
 	return ""
 }
@@ -1141,18 +1151,18 @@ var File_scanoss_api_licenses_v2_scanoss_licenses_proto protoreflect.FileDescrip
 
 const file_scanoss_api_licenses_v2_scanoss_licenses_proto_rawDesc = "" +
 	"\n" +
-	".scanoss/api/licenses/v2/scanoss-licenses.proto\x12\x17scanoss.api.licenses.v2\x1a*scanoss/api/common/v2/scanoss-common.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\xe5\a\n" +
+	".scanoss/api/licenses/v2/scanoss-licenses.proto\x12\x17scanoss.api.licenses.v2\x1a*scanoss/api/common/v2/scanoss-common.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\xec\a\n" +
 	"\x18ComponentLicenseResponse\x12K\n" +
 	"\tcomponent\x18\x01 \x01(\v2-.scanoss.api.licenses.v2.ComponentLicenseInfoR\tcomponent\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xbc\x06\x92A\xb8\x06\n" +
-	"\xb5\x062\x96\x03Success example. For error cases, the component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"error_message\\\":\\\"Component version not found\\\",\\\"error_code\\\":\\\"VERSION_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}J\x99\x03{\"component\":{\"purl\": \"pkg:github/scanoss/engine@1.0.0\", \"requirement\": \"\", \"version\": \"1.0.0\", \"statement\": \"GPL-2.0\", \"licenses\": [{\"id\": \"GPL-2.0\", \"full_name\": \"GNU General Public License v2.0 only\", \"is_spdx_approved\": true, \"url\": \"https://spdx.org/licenses/GPL-2.0-only.html\"}], \"url\": \"https://github.com/scanoss/engine\"}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Licenses Successfully retrieved\"}}\"\x8a\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xc3\x06\x92A\xbf\x06\n" +
+	"\xbc\x062\x9d\x03Success example. For error cases, the component block reports the failure via info_message and info_code. Example: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"info_message\\\":\\\"Component version not found\\\",\\\"info_code\\\":\\\"VERSION_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}J\x99\x03{\"component\":{\"purl\": \"pkg:github/scanoss/engine@1.0.0\", \"requirement\": \"\", \"version\": \"1.0.0\", \"statement\": \"GPL-2.0\", \"licenses\": [{\"id\": \"GPL-2.0\", \"full_name\": \"GNU General Public License v2.0 only\", \"is_spdx_approved\": true, \"url\": \"https://spdx.org/licenses/GPL-2.0-only.html\"}], \"url\": \"https://github.com/scanoss/engine\"}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Licenses Successfully retrieved\"}}\"\x92\n" +
 	"\n" +
 	"\x19ComponentsLicenseResponse\x12M\n" +
 	"\n" +
 	"components\x18\x01 \x03(\v2-.scanoss.api.licenses.v2.ComponentLicenseInfoR\n" +
 	"components\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xde\b\x92A\xda\b\n" +
-	"\xd7\b2\x99\x03Success example. For error cases, the component block includes error_message and error_code fields, e.g.: {\\\"components\\\":[{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"error_message\\\":\\\"Component version not found\\\",\\\"error_code\\\":\\\"VERSION_NOT_FOUND\\\"}],\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}J\xb8\x05{\"components\":[{\"purl\": \"pkg:github/scanoss/engine@1.0.0\", \"requirement\": \"\", \"version\": \"1.0.0\", \"statement\": \"GPL-2.0\", \"licenses\": [{\"id\": \"GPL-2.0\", \"full_name\": \"GNU General Public License v2.0 only\", \"is_spdx_approved\": true, \"url\": \"https://spdx.org/licenses/GPL-2.0-only.html\"}], \"url\": \"https://github.com/scanoss/engine\"}, {\"purl\": \"pkg:github/scanoss/scanoss.py@v1.30.0\",\"requirement\": \"\",\"version\": \"v1.30.0\",\"statement\": \"MIT\", \"licenses\": [{\"id\": \"MIT\",\"full_name\": \"MIT License\", \"is_spdx_approved\": true, \"url\": \"https://spdx.org/licenses/MIT.html\"}], \"url\": \"https://github.com/scanoss/scanoss.py\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Licenses Successfully retrieved\"}}\"\x9a\x01\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xe6\b\x92A\xe2\b\n" +
+	"\xdf\b2\xa1\x03Success example. For error cases, each component block reports the failure via info_message and info_code. Example: {\\\"components\\\":[{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"info_message\\\":\\\"Component version not found\\\",\\\"info_code\\\":\\\"VERSION_NOT_FOUND\\\"}],\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}J\xb8\x05{\"components\":[{\"purl\": \"pkg:github/scanoss/engine@1.0.0\", \"requirement\": \"\", \"version\": \"1.0.0\", \"statement\": \"GPL-2.0\", \"licenses\": [{\"id\": \"GPL-2.0\", \"full_name\": \"GNU General Public License v2.0 only\", \"is_spdx_approved\": true, \"url\": \"https://spdx.org/licenses/GPL-2.0-only.html\"}], \"url\": \"https://github.com/scanoss/engine\"}, {\"purl\": \"pkg:github/scanoss/scanoss.py@v1.30.0\",\"requirement\": \"\",\"version\": \"v1.30.0\",\"statement\": \"MIT\", \"licenses\": [{\"id\": \"MIT\",\"full_name\": \"MIT License\", \"is_spdx_approved\": true, \"url\": \"https://spdx.org/licenses/MIT.html\"}], \"url\": \"https://github.com/scanoss/scanoss.py\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Licenses Successfully retrieved\"}}\"\x9a\x01\n" +
 	"\x16LicenseDetailsResponse\x12A\n" +
 	"\alicense\x18\x01 \x01(\v2'.scanoss.api.licenses.v2.LicenseDetailsR\alicense\x12=\n" +
 	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\"\x96\x01\n" +
@@ -1212,21 +1222,20 @@ const file_scanoss_api_licenses_v2_scanoss_licenses_proto_rawDesc = "" +
 	"\x04spdx\x18\x03 \x01(\v2\x1d.scanoss.api.licenses.v2.SPDXR\x04spdx\x124\n" +
 	"\x05osadl\x18\x04 \x01(\v2\x1e.scanoss.api.licenses.v2.OSADLR\x05osadl\" \n" +
 	"\x0eLicenseRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\"\xc9\x02\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\xc3\x02\n" +
 	"\x14ComponentLicenseInfo\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12 \n" +
 	"\vrequirement\x18\x02 \x01(\tR\vrequirement\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x12\x1c\n" +
 	"\tstatement\x18\x04 \x01(\tR\tstatement\x12@\n" +
-	"\blicenses\x18\x05 \x03(\v2$.scanoss.api.licenses.v2.LicenseInfoR\blicenses\x12)\n" +
-	"\rerror_message\x18\b \x01(\tH\x00R\rerror_message\x88\x01\x01\x12\x10\n" +
+	"\blicenses\x18\x05 \x03(\v2$.scanoss.api.licenses.v2.LicenseInfoR\blicenses\x12\x10\n" +
 	"\x03url\x18\n" +
-	" \x01(\tR\x03url\x12#\n" +
+	" \x01(\tR\x03url\x12'\n" +
+	"\finfo_message\x18\f \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\r \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\v \x01(\tH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code*l\n" +
+	"_info_code*l\n" +
 	"\vLicenseType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\x0e\n" +
 	"\n" +

--- a/protobuf/scanoss/api/licenses/v2/README.md
+++ b/protobuf/scanoss/api/licenses/v2/README.md
@@ -2,6 +2,8 @@
 
 Analyzes software components to identify licensing information.
 
+> **Breaking change:** The `error_message` and `error_code` fields on `ComponentLicenseInfo` have been removed. Component-level processing outcomes are now reported via the `info_message` and `info_code` fields. Clients must migrate to read `info_message`/`info_code`; responses no longer include `error_message`/`error_code`.
+
 ## GetComponentLicenses
 Retrieves license information for a single software component identified by Package URL. 
 Examines source code, license files, and package metadata to determine which licenses apply to the component. 
@@ -33,6 +35,21 @@ The response includes these fields:
 - `version` field: Shows the specific version that was analyzed  
 - `url` field: URL linking to the component's source or repository page
 - `requirement` field: Echoes the client's version constraint from the request
+- `info_code` field: Always populated. Identifies the outcome of processing the component (e.g.`VERSION_NOT_FOUND`)
+- `info_message` field: Human-readable description of the processing outcome. Populated on errors and may be present on success
+
+### Info Codes
+
+The `info_code` field reports the outcome of processing each component. Possible values:
+
+| Code | Meaning |
+|------|---------|
+| `SUCCESS` | Component processed successfully. |
+| `INVALID_PURL` | The provided Package URL (PURL) is invalid or malformed. |
+| `COMPONENT_NOT_FOUND` | The requested component could not be found in the database. |
+| `NO_INFO` | No license information is available for the requested component. |
+| `INVALID_SEMVER` | The provided semantic version (SemVer) is invalid or malformed. |
+| `VERSION_NOT_FOUND` | The specific component version could not be found. |
 
 ### Response Examples
 
@@ -140,7 +157,8 @@ This indicates users must comply with both licenses, generating the SPDX express
 
 
 #### Error in component
-When a component cannot be processed, the response includes `error_message` and `error_code` fields. The remaining fields will be empty since the component could not be resolved:
+When a component cannot be processed, the component block reports the failure via `info_code` and `info_message`. The remaining fields (`licenses`, `statement`, `version`, `url`) will be empty since the component could not be resolved.
+
 ```json
 {
   "component": {
@@ -150,8 +168,8 @@ When a component cannot be processed, the response includes `error_message` and 
     "version": "",
     "statement": "",
     "licenses": [],
-    "error_message": "Component version not found",
-    "error_code": "VERSION_NOT_FOUND"
+    "info_message": "Component version not found",
+    "info_code": "VERSION_NOT_FOUND"
   },
   "status": {
     "status": "SUCCESS",

--- a/protobuf/scanoss/api/licenses/v2/scanoss-licenses.proto
+++ b/protobuf/scanoss/api/licenses/v2/scanoss-licenses.proto
@@ -129,7 +129,7 @@ message ComponentLicenseResponse {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
     json_schema: {
       example: "{\"component\":{\"purl\": \"pkg:github/scanoss/engine@1.0.0\", \"requirement\": \"\", \"version\": \"1.0.0\", \"statement\": \"GPL-2.0\", \"licenses\": [{\"id\": \"GPL-2.0\", \"full_name\": \"GNU General Public License v2.0 only\", \"is_spdx_approved\": true, \"url\": \"https://spdx.org/licenses/GPL-2.0-only.html\"}], \"url\": \"https://github.com/scanoss/engine\"}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Licenses Successfully retrieved\"}}";
-      description: "Success example. For error cases, the component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"error_message\\\":\\\"Component version not found\\\",\\\"error_code\\\":\\\"VERSION_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}";
+      description: "Success example. For error cases, the component block reports the failure via info_message and info_code. Example: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"info_message\\\":\\\"Component version not found\\\",\\\"info_code\\\":\\\"VERSION_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}";
     }
   };
   // License info for the component
@@ -147,7 +147,7 @@ message ComponentsLicenseResponse {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
     json_schema: {
       example: "{\"components\":[{\"purl\": \"pkg:github/scanoss/engine@1.0.0\", \"requirement\": \"\", \"version\": \"1.0.0\", \"statement\": \"GPL-2.0\", \"licenses\": [{\"id\": \"GPL-2.0\", \"full_name\": \"GNU General Public License v2.0 only\", \"is_spdx_approved\": true, \"url\": \"https://spdx.org/licenses/GPL-2.0-only.html\"}], \"url\": \"https://github.com/scanoss/engine\"}, {\"purl\": \"pkg:github/scanoss/scanoss.py@v1.30.0\",\"requirement\": \"\",\"version\": \"v1.30.0\",\"statement\": \"MIT\", \"licenses\": [{\"id\": \"MIT\",\"full_name\": \"MIT License\", \"is_spdx_approved\": true, \"url\": \"https://spdx.org/licenses/MIT.html\"}], \"url\": \"https://github.com/scanoss/scanoss.py\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Licenses Successfully retrieved\"}}";
-      description: "Success example. For error cases, the component block includes error_message and error_code fields, e.g.: {\\\"components\\\":[{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"error_message\\\":\\\"Component version not found\\\",\\\"error_code\\\":\\\"VERSION_NOT_FOUND\\\"}],\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}";
+      description: "Success example. For error cases, each component block reports the failure via info_message and info_code. Example: {\\\"components\\\":[{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"info_message\\\":\\\"Component version not found\\\",\\\"info_code\\\":\\\"VERSION_NOT_FOUND\\\"}],\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}";
     }
   };
   // License info for each component in the batch
@@ -379,10 +379,20 @@ message ComponentLicenseInfo {
   string statement = 4;
   // Individual licenses identified in the component
   repeated LicenseInfo licenses = 5;
-  // Optional error message describing what went wrong during component processing
-  optional string error_message = 8 [json_name = "error_message"];
   // Component URL
   string url = 10 [json_name = "url"];
-  // Optional error code indicating the type of error encountered (moved from position 9).
-  optional string error_code = 11 [json_name = "error_code"];
+  // Status message describing the outcome of processing this component.
+  // Replaces the removed `error_message` field (position 8).
+  optional string info_message = 12 [json_name = "info_message"];
+  // Status code identifying the outcome of processing this component. Always populated.
+  // Replaces the removed `error_code` field (position 11).
+  //
+  // Possible values:
+  //   - "SUCCESS":             Component processed successfully.
+  //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+  //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+  //   - "NO_INFO":             No license information is available for the requested component.
+  //   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+  //   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+  optional string info_code = 13 [json_name = "info_code"];
 }

--- a/protobuf/scanoss/api/licenses/v2/scanoss-licenses.swagger.json
+++ b/protobuf/scanoss/api/licenses/v2/scanoss-licenses.swagger.json
@@ -365,17 +365,17 @@
           },
           "title": "Individual licenses identified in the component"
         },
-        "error_message": {
-          "type": "string",
-          "title": "Optional error message describing what went wrong during component processing"
-        },
         "url": {
           "type": "string",
           "title": "Component URL"
         },
-        "error_code": {
+        "info_message": {
           "type": "string",
-          "description": "Optional error code indicating the type of error encountered (moved from position 9)."
+          "description": "Status message describing the outcome of processing this component.\nReplaces the removed `error_message` field (position 8)."
+        },
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component. Always populated.\nReplaces the removed `error_code` field (position 11).\n\nPossible values:\n  - \"SUCCESS\":             Component processed successfully.\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No license information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "description": "License information for a specific component identified by PURL and version."
@@ -412,7 +412,7 @@
           "$ref": "#/definitions/v2StatusResponse"
         }
       },
-      "description": "Success example. For error cases, the component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"error_message\\\":\\\"Component version not found\\\",\\\"error_code\\\":\\\"VERSION_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}"
+      "description": "Success example. For error cases, the component block reports the failure via info_message and info_code. Example: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"info_message\\\":\\\"Component version not found\\\",\\\"info_code\\\":\\\"VERSION_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}"
     },
     "v2ComponentRequest": {
       "type": "object",
@@ -487,7 +487,7 @@
           "$ref": "#/definitions/v2StatusResponse"
         }
       },
-      "description": "Success example. For error cases, the component block includes error_message and error_code fields, e.g.: {\\\"components\\\":[{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"error_message\\\":\\\"Component version not found\\\",\\\"error_code\\\":\\\"VERSION_NOT_FOUND\\\"}],\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}"
+      "description": "Success example. For error cases, each component block reports the failure via info_message and info_code. Example: {\\\"components\\\":[{\\\"purl\\\":\\\"pkg:github/scanoss/unknown-component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"statement\\\":\\\"\\\",\\\"licenses\\\":[],\\\"url\\\":\\\"\\\",\\\"info_message\\\":\\\"Component version not found\\\",\\\"info_code\\\":\\\"VERSION_NOT_FOUND\\\"}],\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Success\\\"}}"
     },
     "v2ComponentsRequest": {
       "type": "object",


### PR DESCRIPTION
…essage/info_code in ComponentLicenseInfo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Component license responses now report per-component processing status via `info_message` and `info_code` fields for improved outcome tracking

* **Documentation**
  * Updated API schema with new `info_code` enumeration: SUCCESS, INVALID_PURL, COMPONENT_NOT_FOUND, NO_INFO, INVALID_SEMVER, VERSION_NOT_FOUND
  * Response structure refined; `error_message` and `error_code` fields replaced

<!-- end of auto-generated comment: release notes by coderabbit.ai -->