### PR TITLE
chore(vulnerabilities):SP-4321 replace error_message/error_code with …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.0] - 2026-04-17
+### Added
+- Added `info_message` and `info_code` fields to `ComponentVulnerabilityInfo` and `ComponentCpesInfo` messages in Vulnerability responses as the definitive fields for reporting the outcome of processing each component
+### Removed
+- **Breaking change:** Removed `error_message` and `error_code` fields from `ComponentVulnerabilityInfo` and `ComponentCpesInfo` messages in Vulnerability responses. Clients must migrate to `info_message`/`info_code`
+
 ## [0.39.0] - 2026-04-16
 ### Added
 - Added `info_message` and `info_code` fields to `DependencyResponse.Dependencies` message in Dependencies responses as the definitive fields for reporting the outcome of processing each component
@@ -293,6 +299,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Vulnerabilities
 - Added REST endpoint support for each service also
 
+[0.40.0]: https://github.com/scanoss/papi/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/scanoss/papi/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/scanoss/papi/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/scanoss/papi/compare/v0.36.0...v0.37.0

--- a/api/dependenciesv2/scanoss-dependencies.pb.go
+++ b/api/dependenciesv2/scanoss-dependencies.pb.go
@@ -724,7 +724,7 @@ const file_scanoss_api_dependencies_v2_scanoss_dependencies_proto_rawDesc = "" +
 	"\x05Files\x12\x12\n" +
 	"\x04file\x18\x01 \x01(\tR\x04file\x12J\n" +
 	"\x05purls\x18\x02 \x03(\v24.scanoss.api.dependencies.v2.DependencyRequest.PurlsR\x05purls:i\x92Ad\n" +
-	"bJ`{\"files\":[{\"file\":\"package.json\",\"purls\":[{\"purl\":\"pkg:npm/express\",\"requirement\":\"^4.18.0\"}]}]}\x18\x01\"\x91\r\n" +
+	"bJ`{\"files\":[{\"file\":\"package.json\",\"purls\":[{\"purl\":\"pkg:npm/express\",\"requirement\":\"^4.18.0\"}]}]}\x18\x01\"\xb8\r\n" +
 	"\x12DependencyResponse\x12K\n" +
 	"\x05files\x18\x01 \x03(\v25.scanoss.api.dependencies.v2.DependencyResponse.FilesR\x05files\x12=\n" +
 	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1av\n" +
@@ -732,7 +732,7 @@ const file_scanoss_api_dependencies_v2_scanoss_dependencies_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aspdx_id\x18\x02 \x01(\tR\aspdx_id\x12*\n" +
 	"\x10is_spdx_approved\x18\x03 \x01(\bR\x10is_spdx_approved\x12\x10\n" +
-	"\x03url\x18\x04 \x01(\tR\x03url\x1a\xe9\x02\n" +
+	"\x03url\x18\x04 \x01(\tR\x03url\x1a\x90\x03\n" +
 	"\fDependencies\x12\x1c\n" +
 	"\tcomponent\x18\x01 \x01(\tR\tcomponent\x12\x12\n" +
 	"\x04purl\x18\x02 \x01(\tR\x04purl\x12\x18\n" +
@@ -746,7 +746,9 @@ const file_scanoss_api_dependencies_v2_scanoss_dependencies_proto_rawDesc = "" +
 	"\tinfo_code\x18\v \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
 	"\r_info_messageB\f\n" +
 	"\n" +
-	"_info_code\x1a\xa5\x01\n" +
+	"_info_codeJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"R\rerror_messageR\n" +
+	"error_code\x1a\xa5\x01\n" +
 	"\x05Files\x12\x12\n" +
 	"\x04file\x18\x01 \x01(\tR\x04file\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x16\n" +

--- a/api/geoprovenancev2/scanoss-geoprovenance.pb.go
+++ b/api/geoprovenancev2/scanoss-geoprovenance.pb.go
@@ -924,10 +924,10 @@ const file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDesc = ""
 	"\blocation\x18\x02 \x01(\tR\blocation\"A\n" +
 	"\x0fCuratedLocation\x12\x18\n" +
 	"\acountry\x18\x01 \x01(\tR\acountry\x12\x14\n" +
-	"\x05count\x18\x02 \x01(\x05R\x05count\"\xed\x03\n" +
+	"\x05count\x18\x02 \x01(\x05R\x05count\"\x94\x04\n" +
 	"\x13ContributorResponse\x12M\n" +
 	"\x05purls\x18\x01 \x03(\v27.scanoss.api.geoprovenance.v2.ContributorResponse.PurlsR\x05purls\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\xc3\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\xea\x02\n" +
 	"\x05Purls\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12^\n" +
 	"\x12declared_locations\x18\x02 \x03(\v2..scanoss.api.geoprovenance.v2.DeclaredLocationR\x12declared_locations\x12[\n" +
@@ -936,7 +936,8 @@ const file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDesc = ""
 	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
 	"\r_info_messageB\f\n" +
 	"\n" +
-	"_info_code:\x02\x18\x01\"\xd3\x02\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code:\x02\x18\x01\"\xfa\x02\n" +
 	"\x15ComponentLocationInfo\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12^\n" +
 	"\x12declared_locations\x18\x02 \x03(\v2..scanoss.api.geoprovenance.v2.DeclaredLocationR\x12declared_locations\x12[\n" +
@@ -945,7 +946,8 @@ const file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDesc = ""
 	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
 	"\r_info_messageB\f\n" +
 	"\n" +
-	"_info_code\"\xdd\x04\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code\"\xdd\x04\n" +
 	"\x1dComponentsContributorResponse\x12g\n" +
 	"\x14components_locations\x18\x01 \x03(\v23.scanoss.api.geoprovenance.v2.ComponentLocationInfoR\x14components_locations\x12=\n" +
 	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x93\x03\x92A\x8f\x03\n" +
@@ -958,7 +960,7 @@ const file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDesc = ""
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1e\n" +
 	"\n" +
 	"percentage\x18\x02 \x01(\x02R\n" +
-	"percentage\"\xd8\x01\n" +
+	"percentage\"\xff\x01\n" +
 	"\x11ComponentLocation\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12D\n" +
 	"\tlocations\x18\x02 \x03(\v2&.scanoss.api.geoprovenance.v2.LocationR\tlocations\x12'\n" +
@@ -966,10 +968,11 @@ const file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDesc = ""
 	"\tinfo_code\x18\x06 \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
 	"\r_info_messageB\f\n" +
 	"\n" +
-	"_info_code\"\xec\x02\n" +
+	"_info_codeJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05R\rerror_messageR\n" +
+	"error_code\"\x93\x03\n" +
 	"\x0eOriginResponse\x12H\n" +
 	"\x05purls\x18\x01 \x03(\v22.scanoss.api.geoprovenance.v2.OriginResponse.PurlsR\x05purls\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\xcc\x01\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\xf3\x01\n" +
 	"\x05Purls\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12D\n" +
 	"\tlocations\x18\x02 \x03(\v2&.scanoss.api.geoprovenance.v2.LocationR\tlocations\x12'\n" +
@@ -977,7 +980,8 @@ const file_scanoss_api_geoprovenance_v2_scanoss_geoprovenance_proto_rawDesc = ""
 	"\tinfo_code\x18\x06 \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
 	"\r_info_messageB\f\n" +
 	"\n" +
-	"_info_code:\x02\x18\x01\"\xd5\x03\n" +
+	"_info_codeJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05R\rerror_messageR\n" +
+	"error_code:\x02\x18\x01\"\xd5\x03\n" +
 	"\x18ComponentsOriginResponse\x12c\n" +
 	"\x14components_locations\x18\x01 \x03(\v2/.scanoss.api.geoprovenance.v2.ComponentLocationR\x14components_locations\x12=\n" +
 	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x94\x02\x92A\x90\x02\n" +

--- a/api/licensesv2/scanoss-licenses.pb.go
+++ b/api/licensesv2/scanoss-licenses.pb.go
@@ -1221,7 +1221,7 @@ const file_scanoss_api_licenses_v2_scanoss_licenses_proto_rawDesc = "" +
 	"\x04spdx\x18\x03 \x01(\v2\x1d.scanoss.api.licenses.v2.SPDXR\x04spdx\x124\n" +
 	"\x05osadl\x18\x04 \x01(\v2\x1e.scanoss.api.licenses.v2.OSADLR\x05osadl\" \n" +
 	"\x0eLicenseRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\"\xc3\x02\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\xf0\x02\n" +
 	"\x14ComponentLicenseInfo\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12 \n" +
 	"\vrequirement\x18\x02 \x01(\tR\vrequirement\x12\x18\n" +
@@ -1234,7 +1234,9 @@ const file_scanoss_api_licenses_v2_scanoss_licenses_proto_rawDesc = "" +
 	"\tinfo_code\x18\r \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
 	"\r_info_messageB\f\n" +
 	"\n" +
-	"_info_code*l\n" +
+	"_info_codeJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"J\x04\b\v\x10\fR\rerror_messageR\n" +
+	"error_code*l\n" +
 	"\vLicenseType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\x0e\n" +
 	"\n" +

--- a/api/vulnerabilitiesv2/scanoss-vulnerabilities.pb.go
+++ b/api/vulnerabilitiesv2/scanoss-vulnerabilities.pb.go
@@ -176,10 +176,19 @@ type ComponentCpesInfo struct {
 	Requirement string `protobuf:"bytes,3,opt,name=requirement,proto3" json:"requirement,omitempty"`
 	// List of Common Platform Enumeration identifiers associated with this component
 	Cpes []string `protobuf:"bytes,4,rep,name=cpes,proto3" json:"cpes,omitempty"`
-	// Optional error message describing what went wrong during component processing
-	ErrorMessage *string `protobuf:"bytes,5,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	// Optional error code indicating the type of error encountered
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,6,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	// Status message describing the outcome of processing this component.
+	// Replaces the removed `error_message` field (position 5).
+	InfoMessage *string `protobuf:"bytes,7,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	// Replaces the removed `error_code` field (position 6).
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No CPE information is available for the requested component.
+	//   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+	//   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+	InfoCode      *string `protobuf:"bytes,8,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -242,18 +251,18 @@ func (x *ComponentCpesInfo) GetCpes() []string {
 	return nil
 }
 
-func (x *ComponentCpesInfo) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentCpesInfo) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentCpesInfo) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentCpesInfo) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Response message for GetComponentCpes method.
@@ -703,10 +712,19 @@ type ComponentVulnerabilityInfo struct {
 	Requirement string `protobuf:"bytes,3,opt,name=requirement,proto3" json:"requirement,omitempty"`
 	// List of known vulnerabilities affecting this component
 	Vulnerabilities []*Vulnerability `protobuf:"bytes,4,rep,name=vulnerabilities,proto3" json:"vulnerabilities,omitempty"`
-	// Optional error message describing what went wrong during component processing
-	ErrorMessage *string `protobuf:"bytes,5,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	// Optional error code indicating the type of error encountered
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,6,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	// Status message describing the outcome of processing this component.
+	// Replaces the removed `error_message` field (position 5).
+	InfoMessage *string `protobuf:"bytes,7,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	// Replaces the removed `error_code` field (position 6).
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No vulnerability information is available for the requested component.
+	//   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+	//   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+	InfoCode      *string `protobuf:"bytes,8,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -769,18 +787,18 @@ func (x *ComponentVulnerabilityInfo) GetVulnerabilities() []*Vulnerability {
 	return nil
 }
 
-func (x *ComponentVulnerabilityInfo) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentVulnerabilityInfo) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentVulnerabilityInfo) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentVulnerabilityInfo) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Response message for GetComponentVulnerabilities method.
@@ -1079,28 +1097,28 @@ const file_scanoss_api_vulnerabilities_v2_scanoss_vulnerabilities_proto_rawDesc 
 	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a/\n" +
 	"\x05Purls\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x12\n" +
-	"\x04cpes\x18\x02 \x03(\tR\x04cpes:\x02\x18\x01\"\x8a\x02\n" +
+	"\x04cpes\x18\x02 \x03(\tR\x04cpes:\x02\x18\x01\"\x89\x02\n" +
 	"\x11ComponentCpesInfo\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12 \n" +
 	"\vrequirement\x18\x03 \x01(\tR\vrequirement\x12\x12\n" +
-	"\x04cpes\x18\x04 \x03(\tR\x04cpes\x12)\n" +
-	"\rerror_message\x18\x05 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x04cpes\x18\x04 \x03(\tR\x04cpes\x12'\n" +
+	"\finfo_message\x18\a \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\b \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x06 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code\"\x97\x06\n" +
+	"_info_codeJ\x04\b\x05\x10\x06J\x04\b\x06\x10\aR\rerror_messageR\n" +
+	"error_code\"\x8b\x06\n" +
 	"\x15ComponentCpesResponse\x12O\n" +
 	"\tcomponent\x18\x01 \x01(\v21.scanoss.api.vulnerabilities.v2.ComponentCpesInfoR\tcomponent\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xed\x04\x92A\xe9\x04\n" +
-	"\xe6\x042\xf6\x02Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"cpes\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}J\xea\x01{\"component\":{\"purl\": \"pkg:github/scanoss/engine@1.0.0\", \"requirement\": \"1.0.0\", \"version\": \"1.0.0\", \"cpes\": [\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\"]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"CPEs Successfully retrieved\"}}\"\xca\b\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xe1\x04\x92A\xdd\x04\n" +
+	"\xda\x042\xea\x02Success example. For error cases, each component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"cpes\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}J\xea\x01{\"component\":{\"purl\": \"pkg:github/scanoss/engine@1.0.0\", \"requirement\": \"1.0.0\", \"version\": \"1.0.0\", \"cpes\": [\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\"]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"CPEs Successfully retrieved\"}}\"\xae\b\n" +
 	"\x16ComponentsCpesResponse\x12Q\n" +
 	"\n" +
 	"components\x18\x01 \x03(\v21.scanoss.api.vulnerabilities.v2.ComponentCpesInfoR\n" +
 	"components\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x9d\a\x92A\x99\a\n" +
-	"\x96\a2\x8e\x04Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"components\\\":[{\\\"purl\\\":\\\"pkg:github/scanoss/engine\\\",\\\"requirement\\\":\\\"1.0.0\\\",\\\"version\\\":\\\"1.0.0\\\",\\\"cpes\\\":[\\\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\\\"]},{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"cpes\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"}],\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}J\x82\x03{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \"1.0.0\", \"version\": \"1.0.0\", \"cpes\": [\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\"]}, {\"purl\": \"pkg:github/scanoss/scanoss.py@v1.30.0\",\"requirement\": \"\",\"version\": \"v1.30.0\", \"cpes\": [\"cpe:2.3:a:scanoss:scanoss.py:1.30.0:*:*:*:*:*:*:*\"]}  ], \"status\": {\"status\": \"SUCCESS\", \"message\": \"CPEs Successfully retrieved\"}}\"`\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x81\a\x92A\xfd\x06\n" +
+	"\xfa\x062\xf2\x03Success example. For error cases, each component block reports the processing status via info_message and info_code. Example: {\"components\":[{\"purl\":\"pkg:github/scanoss/engine\",\"requirement\":\"1.0.0\",\"version\":\"1.0.0\",\"cpes\":[\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\"]},{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"cpes\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}J\x82\x03{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \"1.0.0\", \"version\": \"1.0.0\", \"cpes\": [\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\"]}, {\"purl\": \"pkg:github/scanoss/scanoss.py@v1.30.0\",\"requirement\": \"\",\"version\": \"v1.30.0\", \"cpes\": [\"cpe:2.3:a:scanoss:scanoss.py:1.30.0:*:*:*:*:*:*:*\"]}  ], \"status\": {\"status\": \"SUCCESS\", \"message\": \"CPEs Successfully retrieved\"}}\"`\n" +
 	"\x04CVSS\x12\x12\n" +
 	"\x04cvss\x18\x01 \x01(\tR\x04cvss\x12\x1e\n" +
 	"\n" +
@@ -1129,28 +1147,28 @@ const file_scanoss_api_vulnerabilities_v2_scanoss_vulnerabilities_proto_rawDesc 
 	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1at\n" +
 	"\x05Purls\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12W\n" +
-	"\x0fvulnerabilities\x18\x02 \x03(\v2-.scanoss.api.vulnerabilities.v2.VulnerabilityR\x0fvulnerabilities:\x02\x18\x01\"\xd8\x02\n" +
+	"\x0fvulnerabilities\x18\x02 \x03(\v2-.scanoss.api.vulnerabilities.v2.VulnerabilityR\x0fvulnerabilities:\x02\x18\x01\"\xd7\x02\n" +
 	"\x1aComponentVulnerabilityInfo\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12 \n" +
 	"\vrequirement\x18\x03 \x01(\tR\vrequirement\x12W\n" +
-	"\x0fvulnerabilities\x18\x04 \x03(\v2-.scanoss.api.vulnerabilities.v2.VulnerabilityR\x0fvulnerabilities\x12)\n" +
-	"\rerror_message\x18\x05 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x0fvulnerabilities\x18\x04 \x03(\v2-.scanoss.api.vulnerabilities.v2.VulnerabilityR\x0fvulnerabilities\x12'\n" +
+	"\finfo_message\x18\a \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\b \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x06 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code\"\xac\t\n" +
+	"_info_codeJ\x04\b\x05\x10\x06J\x04\b\x06\x10\aR\rerror_messageR\n" +
+	"error_code\"\xc1\t\n" +
 	"\x1eComponentVulnerabilityResponse\x12X\n" +
 	"\tcomponent\x18\x01 \x01(\v2:.scanoss.api.vulnerabilities.v2.ComponentVulnerabilityInfoR\tcomponent\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xf0\a\x92A\xec\a\n" +
-	"\xe9\a2\xdf\x02Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"error_message\":\"Component not found in database\",\"error_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}J\x84\x05{\"component\":{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \"=>1.0.0\", \"version\": \"1.0.0\", \"vulnerabilities\": [{\"id\": \"CVE-1999-0214\", \"cve\": \"CVE-1999-0214\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-1999-0214\", \"summary\": \"Denial of service by sending forged ICMP unreachable packets\", \"severity\": \"High\", \"published\": \"1992-07-21\", \"modified\": \"2025-04-02\", \"source\": \"NVD\", \"cvss\": [{\"cvss\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"cvss_score\": 7.5, \"cvss_severity\": \"High\"}], \"epss\": {\"probability\": 0.00483, \"percentile\": 0.64405}}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Vulnerabilities Successfully retrieved\"}}\"\xcf\x0e\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x85\b\x92A\x81\b\n" +
+	"\xfe\a2\xf4\x02Success example. For error cases, the component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}J\x84\x05{\"component\":{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \"=>1.0.0\", \"version\": \"1.0.0\", \"vulnerabilities\": [{\"id\": \"CVE-1999-0214\", \"cve\": \"CVE-1999-0214\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-1999-0214\", \"summary\": \"Denial of service by sending forged ICMP unreachable packets\", \"severity\": \"High\", \"published\": \"1992-07-21\", \"modified\": \"2025-04-02\", \"source\": \"NVD\", \"cvss\": [{\"cvss\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"cvss_score\": 7.5, \"cvss_severity\": \"High\"}], \"epss\": {\"probability\": 0.00483, \"percentile\": 0.64405}}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Vulnerabilities Successfully retrieved\"}}\"\xe5\x0e\n" +
 	"\x1fComponentsVulnerabilityResponse\x12Z\n" +
 	"\n" +
 	"components\x18\x01 \x03(\v2:.scanoss.api.vulnerabilities.v2.ComponentVulnerabilityInfoR\n" +
 	"components\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x90\r\x92A\x8c\r\n" +
-	"\x89\r2\xf0\x03Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\"components\":[{\"purl\":\"pkg:github/scanoss/engine\",\"requirement\":\"1.0.0\",\"version\":\"1.0.0\",\"vulnerabilities\":[{\"id\":\"CVE-1999-0214\",\"cve\":\"CVE-1999-0214\"}]},{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"error_message\":\"Component not found in database\",\"error_code\":\"COMPONENT_NOT_FOUND\"}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}J\x93\t{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \"1.0.0\", \"version\": \"1.0.0\", \"vulnerabilities\": [{\"id\": \"CVE-1999-0214\", \"cve\": \"CVE-1999-0214\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-1999-0214\", \"summary\": \"Denial of service by sending forged ICMP unreachable packets\", \"severity\": \"High\", \"published\": \"1992-07-21\", \"modified\": \"2025-04-02\", \"source\": \"NVD\", \"cvss\": [{\"cvss\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"cvss_score\": 7.5, \"cvss_severity\": \"High\"}], \"epss\": {\"probability\": 0.00483, \"percentile\": 0.64405}}]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\",\"requirement\": \"v1.30.0\",\"version\": \"v1.30.0\", \"vulnerabilities\": [{\"id\": \"CVE-2024-54321\", \"cve\": \"CVE-2024-54321\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-2024-54321\", \"summary\": \"Denial of service vulnerability\", \"severity\": \"Medium\", \"published\": \"2024-01-15\", \"modified\": \"2024-02-01\", \"source\": \"NDV\", \"cvss\": [{\"cvss\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L\", \"cvss_score\": 4.3, \"cvss_severity\": \"Medium\"}], \"epss\": {\"probability\": 0.0012, \"percentile\": 0.3162}}]}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Vulnerabilities Successfully retrieved\"}}2\xb3\b\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xa6\r\x92A\xa2\r\n" +
+	"\x9f\r2\x86\x04Success example. For error cases, each component block reports the processing status via info_message and info_code. Example: {\"components\":[{\"purl\":\"pkg:github/scanoss/engine\",\"requirement\":\"1.0.0\",\"version\":\"1.0.0\",\"vulnerabilities\":[{\"id\":\"CVE-1999-0214\",\"cve\":\"CVE-1999-0214\"}]},{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}J\x93\t{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \"1.0.0\", \"version\": \"1.0.0\", \"vulnerabilities\": [{\"id\": \"CVE-1999-0214\", \"cve\": \"CVE-1999-0214\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-1999-0214\", \"summary\": \"Denial of service by sending forged ICMP unreachable packets\", \"severity\": \"High\", \"published\": \"1992-07-21\", \"modified\": \"2025-04-02\", \"source\": \"NVD\", \"cvss\": [{\"cvss\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"cvss_score\": 7.5, \"cvss_severity\": \"High\"}], \"epss\": {\"probability\": 0.00483, \"percentile\": 0.64405}}]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\",\"requirement\": \"v1.30.0\",\"version\": \"v1.30.0\", \"vulnerabilities\": [{\"id\": \"CVE-2024-54321\", \"cve\": \"CVE-2024-54321\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-2024-54321\", \"summary\": \"Denial of service vulnerability\", \"severity\": \"Medium\", \"published\": \"2024-01-15\", \"modified\": \"2024-02-01\", \"source\": \"NDV\", \"cvss\": [{\"cvss\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L\", \"cvss_score\": 4.3, \"cvss_severity\": \"Medium\"}], \"epss\": {\"probability\": 0.0012, \"percentile\": 0.3162}}]}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Vulnerabilities Successfully retrieved\"}}2\xb3\b\n" +
 	"\x0fVulnerabilities\x12t\n" +
 	"\x04Echo\x12\".scanoss.api.common.v2.EchoRequest\x1a#.scanoss.api.common.v2.EchoResponse\"#\x82\xd3\xe4\x93\x02\x1d:\x01*\"\x18/v2/vulnerabilities/echo\x12q\n" +
 	"\aGetCpes\x124.scanoss.api.vulnerabilities.v2.VulnerabilityRequest\x1a+.scanoss.api.vulnerabilities.v2.CpeResponse\"\x03\x88\x02\x01\x12\x9e\x01\n" +
@@ -1195,51 +1213,48 @@ var file_scanoss_api_vulnerabilities_v2_scanoss_vulnerabilities_proto_goTypes = 
 	(*CpeResponse_Purls)(nil),               // 13: scanoss.api.vulnerabilities.v2.CpeResponse.Purls
 	(*VulnerabilityResponse_Purls)(nil),     // 14: scanoss.api.vulnerabilities.v2.VulnerabilityResponse.Purls
 	(*commonv2.StatusResponse)(nil),         // 15: scanoss.api.common.v2.StatusResponse
-	(commonv2.ErrorCode)(0),                 // 16: scanoss.api.common.v2.ErrorCode
-	(*commonv2.EchoRequest)(nil),            // 17: scanoss.api.common.v2.EchoRequest
-	(*commonv2.ComponentRequest)(nil),       // 18: scanoss.api.common.v2.ComponentRequest
-	(*commonv2.ComponentsRequest)(nil),      // 19: scanoss.api.common.v2.ComponentsRequest
-	(*commonv2.EchoResponse)(nil),           // 20: scanoss.api.common.v2.EchoResponse
+	(*commonv2.EchoRequest)(nil),            // 16: scanoss.api.common.v2.EchoRequest
+	(*commonv2.ComponentRequest)(nil),       // 17: scanoss.api.common.v2.ComponentRequest
+	(*commonv2.ComponentsRequest)(nil),      // 18: scanoss.api.common.v2.ComponentsRequest
+	(*commonv2.EchoResponse)(nil),           // 19: scanoss.api.common.v2.EchoResponse
 }
 var file_scanoss_api_vulnerabilities_v2_scanoss_vulnerabilities_proto_depIdxs = []int32{
 	12, // 0: scanoss.api.vulnerabilities.v2.VulnerabilityRequest.purls:type_name -> scanoss.api.vulnerabilities.v2.VulnerabilityRequest.Purls
 	13, // 1: scanoss.api.vulnerabilities.v2.CpeResponse.purls:type_name -> scanoss.api.vulnerabilities.v2.CpeResponse.Purls
 	15, // 2: scanoss.api.vulnerabilities.v2.CpeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	16, // 3: scanoss.api.vulnerabilities.v2.ComponentCpesInfo.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	2,  // 4: scanoss.api.vulnerabilities.v2.ComponentCpesResponse.component:type_name -> scanoss.api.vulnerabilities.v2.ComponentCpesInfo
-	15, // 5: scanoss.api.vulnerabilities.v2.ComponentCpesResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	2,  // 6: scanoss.api.vulnerabilities.v2.ComponentsCpesResponse.components:type_name -> scanoss.api.vulnerabilities.v2.ComponentCpesInfo
-	15, // 7: scanoss.api.vulnerabilities.v2.ComponentsCpesResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	5,  // 8: scanoss.api.vulnerabilities.v2.Vulnerability.cvss:type_name -> scanoss.api.vulnerabilities.v2.CVSS
-	6,  // 9: scanoss.api.vulnerabilities.v2.Vulnerability.epss:type_name -> scanoss.api.vulnerabilities.v2.EPSS
-	14, // 10: scanoss.api.vulnerabilities.v2.VulnerabilityResponse.purls:type_name -> scanoss.api.vulnerabilities.v2.VulnerabilityResponse.Purls
-	15, // 11: scanoss.api.vulnerabilities.v2.VulnerabilityResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	7,  // 12: scanoss.api.vulnerabilities.v2.ComponentVulnerabilityInfo.vulnerabilities:type_name -> scanoss.api.vulnerabilities.v2.Vulnerability
-	16, // 13: scanoss.api.vulnerabilities.v2.ComponentVulnerabilityInfo.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	9,  // 14: scanoss.api.vulnerabilities.v2.ComponentVulnerabilityResponse.component:type_name -> scanoss.api.vulnerabilities.v2.ComponentVulnerabilityInfo
-	15, // 15: scanoss.api.vulnerabilities.v2.ComponentVulnerabilityResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	9,  // 16: scanoss.api.vulnerabilities.v2.ComponentsVulnerabilityResponse.components:type_name -> scanoss.api.vulnerabilities.v2.ComponentVulnerabilityInfo
-	15, // 17: scanoss.api.vulnerabilities.v2.ComponentsVulnerabilityResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	7,  // 18: scanoss.api.vulnerabilities.v2.VulnerabilityResponse.Purls.vulnerabilities:type_name -> scanoss.api.vulnerabilities.v2.Vulnerability
-	17, // 19: scanoss.api.vulnerabilities.v2.Vulnerabilities.Echo:input_type -> scanoss.api.common.v2.EchoRequest
-	0,  // 20: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetCpes:input_type -> scanoss.api.vulnerabilities.v2.VulnerabilityRequest
-	18, // 21: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentCpes:input_type -> scanoss.api.common.v2.ComponentRequest
-	19, // 22: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentsCpes:input_type -> scanoss.api.common.v2.ComponentsRequest
-	0,  // 23: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetVulnerabilities:input_type -> scanoss.api.vulnerabilities.v2.VulnerabilityRequest
-	18, // 24: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentVulnerabilities:input_type -> scanoss.api.common.v2.ComponentRequest
-	19, // 25: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentsVulnerabilities:input_type -> scanoss.api.common.v2.ComponentsRequest
-	20, // 26: scanoss.api.vulnerabilities.v2.Vulnerabilities.Echo:output_type -> scanoss.api.common.v2.EchoResponse
-	1,  // 27: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetCpes:output_type -> scanoss.api.vulnerabilities.v2.CpeResponse
-	3,  // 28: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentCpes:output_type -> scanoss.api.vulnerabilities.v2.ComponentCpesResponse
-	4,  // 29: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentsCpes:output_type -> scanoss.api.vulnerabilities.v2.ComponentsCpesResponse
-	8,  // 30: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetVulnerabilities:output_type -> scanoss.api.vulnerabilities.v2.VulnerabilityResponse
-	10, // 31: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentVulnerabilities:output_type -> scanoss.api.vulnerabilities.v2.ComponentVulnerabilityResponse
-	11, // 32: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentsVulnerabilities:output_type -> scanoss.api.vulnerabilities.v2.ComponentsVulnerabilityResponse
-	26, // [26:33] is the sub-list for method output_type
-	19, // [19:26] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	2,  // 3: scanoss.api.vulnerabilities.v2.ComponentCpesResponse.component:type_name -> scanoss.api.vulnerabilities.v2.ComponentCpesInfo
+	15, // 4: scanoss.api.vulnerabilities.v2.ComponentCpesResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	2,  // 5: scanoss.api.vulnerabilities.v2.ComponentsCpesResponse.components:type_name -> scanoss.api.vulnerabilities.v2.ComponentCpesInfo
+	15, // 6: scanoss.api.vulnerabilities.v2.ComponentsCpesResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	5,  // 7: scanoss.api.vulnerabilities.v2.Vulnerability.cvss:type_name -> scanoss.api.vulnerabilities.v2.CVSS
+	6,  // 8: scanoss.api.vulnerabilities.v2.Vulnerability.epss:type_name -> scanoss.api.vulnerabilities.v2.EPSS
+	14, // 9: scanoss.api.vulnerabilities.v2.VulnerabilityResponse.purls:type_name -> scanoss.api.vulnerabilities.v2.VulnerabilityResponse.Purls
+	15, // 10: scanoss.api.vulnerabilities.v2.VulnerabilityResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	7,  // 11: scanoss.api.vulnerabilities.v2.ComponentVulnerabilityInfo.vulnerabilities:type_name -> scanoss.api.vulnerabilities.v2.Vulnerability
+	9,  // 12: scanoss.api.vulnerabilities.v2.ComponentVulnerabilityResponse.component:type_name -> scanoss.api.vulnerabilities.v2.ComponentVulnerabilityInfo
+	15, // 13: scanoss.api.vulnerabilities.v2.ComponentVulnerabilityResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	9,  // 14: scanoss.api.vulnerabilities.v2.ComponentsVulnerabilityResponse.components:type_name -> scanoss.api.vulnerabilities.v2.ComponentVulnerabilityInfo
+	15, // 15: scanoss.api.vulnerabilities.v2.ComponentsVulnerabilityResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	7,  // 16: scanoss.api.vulnerabilities.v2.VulnerabilityResponse.Purls.vulnerabilities:type_name -> scanoss.api.vulnerabilities.v2.Vulnerability
+	16, // 17: scanoss.api.vulnerabilities.v2.Vulnerabilities.Echo:input_type -> scanoss.api.common.v2.EchoRequest
+	0,  // 18: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetCpes:input_type -> scanoss.api.vulnerabilities.v2.VulnerabilityRequest
+	17, // 19: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentCpes:input_type -> scanoss.api.common.v2.ComponentRequest
+	18, // 20: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentsCpes:input_type -> scanoss.api.common.v2.ComponentsRequest
+	0,  // 21: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetVulnerabilities:input_type -> scanoss.api.vulnerabilities.v2.VulnerabilityRequest
+	17, // 22: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentVulnerabilities:input_type -> scanoss.api.common.v2.ComponentRequest
+	18, // 23: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentsVulnerabilities:input_type -> scanoss.api.common.v2.ComponentsRequest
+	19, // 24: scanoss.api.vulnerabilities.v2.Vulnerabilities.Echo:output_type -> scanoss.api.common.v2.EchoResponse
+	1,  // 25: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetCpes:output_type -> scanoss.api.vulnerabilities.v2.CpeResponse
+	3,  // 26: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentCpes:output_type -> scanoss.api.vulnerabilities.v2.ComponentCpesResponse
+	4,  // 27: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentsCpes:output_type -> scanoss.api.vulnerabilities.v2.ComponentsCpesResponse
+	8,  // 28: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetVulnerabilities:output_type -> scanoss.api.vulnerabilities.v2.VulnerabilityResponse
+	10, // 29: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentVulnerabilities:output_type -> scanoss.api.vulnerabilities.v2.ComponentVulnerabilityResponse
+	11, // 30: scanoss.api.vulnerabilities.v2.Vulnerabilities.GetComponentsVulnerabilities:output_type -> scanoss.api.vulnerabilities.v2.ComponentsVulnerabilityResponse
+	24, // [24:31] is the sub-list for method output_type
+	17, // [17:24] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_scanoss_api_vulnerabilities_v2_scanoss_vulnerabilities_proto_init() }

--- a/protobuf/scanoss/api/dependencies/v2/scanoss-dependencies.proto
+++ b/protobuf/scanoss/api/dependencies/v2/scanoss-dependencies.proto
@@ -149,6 +149,15 @@ message DependencyResponse {
     string url = 5;
     string comment = 6;
     string requirement = 7;
+
+    // Field 8 previously held `string error_message`; field 9 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 8, 9;
+    reserved "error_message", "error_code";
+
     // Status message describing the outcome of processing this component.
     // Replaces the removed `error_message` field (position 8).
     optional string info_message = 10 [json_name = "info_message"];

--- a/protobuf/scanoss/api/geoprovenance/v2/scanoss-geoprovenance.proto
+++ b/protobuf/scanoss/api/geoprovenance/v2/scanoss-geoprovenance.proto
@@ -166,6 +166,15 @@ message ContributorResponse {
     repeated DeclaredLocation declared_locations = 2 [json_name = "declared_locations"];
     // List of SCANOSS curated locations based on analysis
     repeated CuratedLocation curated_locations = 3 [json_name = "curated_locations"];
+
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
     // Status message describing the outcome of processing this component.
     // Replaces the removed `error_message` field (position 4).
     optional string info_message = 6 [json_name = "info_message"];
@@ -194,6 +203,15 @@ message ComponentLocationInfo {
   repeated DeclaredLocation declared_locations = 2 [json_name = "declared_locations"];
   // List of SCANOSS curated locations based on analysis
   repeated CuratedLocation curated_locations = 3 [json_name = "curated_locations"];
+
+  // Field 4 previously held `string error_message`; field 5 previously held
+  // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were replaced
+  // by `info_message`/`info_code` below. These numbers and JSON names must
+  // never be reused, to avoid wire-type or semantic collisions with legacy
+  // clients still encoding them.
+  reserved 4, 5;
+  reserved "error_message", "error_code";
+
   // Status message describing the outcome of processing this component.
   // Replaces the removed `error_message` field (position 4).
   optional string info_message = 6 [json_name = "info_message"];
@@ -257,6 +275,15 @@ message ComponentLocation {
   string purl = 1;
   // The list of countries with contributors and their percentages
   repeated Location locations = 2;
+
+  // Field 3 previously held `string error_message`; field 4 previously held
+  // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were replaced
+  // by `info_message`/`info_code` below. These numbers and JSON names must
+  // never be reused, to avoid wire-type or semantic collisions with legacy
+  // clients still encoding them.
+  reserved 3, 4;
+  reserved "error_message", "error_code";
+
   // Status message describing the outcome of processing this component.
   // Replaces the removed `error_message` field (position 3).
   optional string info_message = 5 [json_name = "info_message"];
@@ -285,6 +312,15 @@ message OriginResponse {
     string purl = 1;
     // The list of countries with contributors and their percentages
     repeated Location locations = 2;
+
+    // Field 3 previously held `string error_message`; field 4 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 3, 4;
+    reserved "error_message", "error_code";
+
     // Status message describing the outcome of processing this component.
     // Replaces the removed `error_message` field (position 3).
     optional string info_message = 5 [json_name = "info_message"];

--- a/protobuf/scanoss/api/licenses/v2/scanoss-licenses.proto
+++ b/protobuf/scanoss/api/licenses/v2/scanoss-licenses.proto
@@ -381,6 +381,16 @@ message ComponentLicenseInfo {
   repeated LicenseInfo licenses = 5;
   // Component URL
   string url = 10 [json_name = "url"];
+
+  // Field 8 previously held `string error_message`. Field 9 previously held
+  // `common.v2.ErrorCode error_code` (enum, varint-wire), later migrated to
+  // `string error_code` at field 11. All three were replaced by
+  // `info_message`/`info_code` below. These numbers and JSON names must
+  // never be reused, to avoid wire-type or semantic collisions with legacy
+  // clients still encoding them.
+  reserved 8, 9, 11;
+  reserved "error_message", "error_code";
+
   // Status message describing the outcome of processing this component.
   // Replaces the removed `error_message` field (position 8).
   optional string info_message = 12 [json_name = "info_message"];

--- a/protobuf/scanoss/api/vulnerabilities/v2/README.md
+++ b/protobuf/scanoss/api/vulnerabilities/v2/README.md
@@ -2,6 +2,8 @@
 
 Provides vulnerability intelligence for software components including CPE enumeration and vulnerability analysis.
 
+> **Breaking change:** The `error_message` and `error_code` fields on `ComponentVulnerabilityInfo` and `ComponentCpesInfo` have been removed. Component-level processing outcomes are now reported via the `info_message` and `info_code` fields. Clients must migrate to read `info_message`/`info_code`; responses no longer include `error_message`/`error_code`.
+
 ## GetComponentCpes
 
 Retrieves Common Platform Enumeration (CPE) identifiers for a single software component identified by Package URL. 

--- a/protobuf/scanoss/api/vulnerabilities/v2/scanoss-vulnerabilities.proto
+++ b/protobuf/scanoss/api/vulnerabilities/v2/scanoss-vulnerabilities.proto
@@ -219,10 +219,27 @@ message ComponentCpesInfo {
   // List of Common Platform Enumeration identifiers associated with this component
   repeated string cpes = 4;
 
-  // Optional error message describing what went wrong during component processing
-  optional string error_message = 5 [json_name = "error_message"];
-  // Optional error code indicating the type of error encountered
-  optional common.v2.ErrorCode error_code = 6  [json_name = "error_code"];
+  // Field 5 previously held `string error_message`; field 6 previously held
+  // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were replaced
+  // by `info_message`/`info_code` below. These numbers and JSON names must
+  // never be reused, to avoid wire-type or semantic collisions with legacy
+  // clients still encoding them.
+  reserved 5, 6;
+  reserved "error_message", "error_code";
+
+  // Status message describing the outcome of processing this component.
+  // Replaces the removed `error_message` field (position 5).
+  optional string info_message = 7 [json_name = "info_message"];
+  // Status code identifying the outcome of processing this component.
+  // Replaces the removed `error_code` field (position 6).
+  //
+  // Possible values:
+  //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+  //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+  //   - "NO_INFO":             No CPE information is available for the requested component.
+  //   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+  //   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+  optional string info_code = 8 [json_name = "info_code"];
 }
 
 /*
@@ -235,7 +252,7 @@ message ComponentCpesResponse {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
     json_schema: {
       example: "{\"component\":{\"purl\": \"pkg:github/scanoss/engine@1.0.0\", \"requirement\": \"1.0.0\", \"version\": \"1.0.0\", \"cpes\": [\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\"]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"CPEs Successfully retrieved\"}}";
-      description: "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"cpes\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}";
+      description: "Success example. For error cases, each component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"cpes\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}";
     }
   };
   // CPE information for the component
@@ -254,7 +271,7 @@ message ComponentsCpesResponse {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
     json_schema: {
       example: "{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \"1.0.0\", \"version\": \"1.0.0\", \"cpes\": [\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\"]}, {\"purl\": \"pkg:github/scanoss/scanoss.py@v1.30.0\",\"requirement\": \"\",\"version\": \"v1.30.0\", \"cpes\": [\"cpe:2.3:a:scanoss:scanoss.py:1.30.0:*:*:*:*:*:*:*\"]}  ], \"status\": {\"status\": \"SUCCESS\", \"message\": \"CPEs Successfully retrieved\"}}";
-      description: "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"components\\\":[{\\\"purl\\\":\\\"pkg:github/scanoss/engine\\\",\\\"requirement\\\":\\\"1.0.0\\\",\\\"version\\\":\\\"1.0.0\\\",\\\"cpes\\\":[\\\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\\\"]},{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"cpes\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"}],\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}";
+      description: "Success example. For error cases, each component block reports the processing status via info_message and info_code. Example: {\"components\":[{\"purl\":\"pkg:github/scanoss/engine\",\"requirement\":\"1.0.0\",\"version\":\"1.0.0\",\"cpes\":[\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\"]},{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"cpes\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}";
     }
   };
   // CPE information for each component in the batch
@@ -363,10 +380,27 @@ message ComponentVulnerabilityInfo {
   // List of known vulnerabilities affecting this component
   repeated Vulnerability vulnerabilities = 4;
 
-  // Optional error message describing what went wrong during component processing
-  optional string error_message = 5 [json_name = "error_message"];
-  // Optional error code indicating the type of error encountered
-  optional common.v2.ErrorCode error_code = 6  [json_name = "error_code"];
+  // Field 5 previously held `string error_message`; field 6 previously held
+  // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were replaced
+  // by `info_message`/`info_code` below. These numbers and JSON names must
+  // never be reused, to avoid wire-type or semantic collisions with legacy
+  // clients still encoding them.
+  reserved 5, 6;
+  reserved "error_message", "error_code";
+
+  // Status message describing the outcome of processing this component.
+  // Replaces the removed `error_message` field (position 5).
+  optional string info_message = 7 [json_name = "info_message"];
+  // Status code identifying the outcome of processing this component.
+  // Replaces the removed `error_code` field (position 6).
+  //
+  // Possible values:
+  //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+  //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+  //   - "NO_INFO":             No vulnerability information is available for the requested component.
+  //   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+  //   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+  optional string info_code = 8 [json_name = "info_code"];
 }
 
 /*
@@ -378,7 +412,7 @@ message ComponentVulnerabilityInfo {
 message ComponentVulnerabilityResponse {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
     json_schema: {
-      description: "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"error_message\":\"Component not found in database\",\"error_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}";
+      description: "Success example. For error cases, the component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}";
       example: "{\"component\":{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \"=>1.0.0\", \"version\": \"1.0.0\", \"vulnerabilities\": [{\"id\": \"CVE-1999-0214\", \"cve\": \"CVE-1999-0214\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-1999-0214\", \"summary\": \"Denial of service by sending forged ICMP unreachable packets\", \"severity\": \"High\", \"published\": \"1992-07-21\", \"modified\": \"2025-04-02\", \"source\": \"NVD\", \"cvss\": [{\"cvss\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"cvss_score\": 7.5, \"cvss_severity\": \"High\"}], \"epss\": {\"probability\": 0.00483, \"percentile\": 0.64405}}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Vulnerabilities Successfully retrieved\"}}";
     }
   };
@@ -397,7 +431,7 @@ message ComponentVulnerabilityResponse {
 message ComponentsVulnerabilityResponse {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
     json_schema: {
-      description: "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\"components\":[{\"purl\":\"pkg:github/scanoss/engine\",\"requirement\":\"1.0.0\",\"version\":\"1.0.0\",\"vulnerabilities\":[{\"id\":\"CVE-1999-0214\",\"cve\":\"CVE-1999-0214\"}]},{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"error_message\":\"Component not found in database\",\"error_code\":\"COMPONENT_NOT_FOUND\"}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}";
+      description: "Success example. For error cases, each component block reports the processing status via info_message and info_code. Example: {\"components\":[{\"purl\":\"pkg:github/scanoss/engine\",\"requirement\":\"1.0.0\",\"version\":\"1.0.0\",\"vulnerabilities\":[{\"id\":\"CVE-1999-0214\",\"cve\":\"CVE-1999-0214\"}]},{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}";
       example: "{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \"1.0.0\", \"version\": \"1.0.0\", \"vulnerabilities\": [{\"id\": \"CVE-1999-0214\", \"cve\": \"CVE-1999-0214\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-1999-0214\", \"summary\": \"Denial of service by sending forged ICMP unreachable packets\", \"severity\": \"High\", \"published\": \"1992-07-21\", \"modified\": \"2025-04-02\", \"source\": \"NVD\", \"cvss\": [{\"cvss\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"cvss_score\": 7.5, \"cvss_severity\": \"High\"}], \"epss\": {\"probability\": 0.00483, \"percentile\": 0.64405}}]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\",\"requirement\": \"v1.30.0\",\"version\": \"v1.30.0\", \"vulnerabilities\": [{\"id\": \"CVE-2024-54321\", \"cve\": \"CVE-2024-54321\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-2024-54321\", \"summary\": \"Denial of service vulnerability\", \"severity\": \"Medium\", \"published\": \"2024-01-15\", \"modified\": \"2024-02-01\", \"source\": \"NDV\", \"cvss\": [{\"cvss\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L\", \"cvss_score\": 4.3, \"cvss_severity\": \"Medium\"}], \"epss\": {\"probability\": 0.0012, \"percentile\": 0.3162}}]}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Vulnerabilities Successfully retrieved\"}}";
     }
   };

--- a/protobuf/scanoss/api/vulnerabilities/v2/scanoss-vulnerabilities.swagger.json
+++ b/protobuf/scanoss/api/vulnerabilities/v2/scanoss-vulnerabilities.swagger.json
@@ -341,13 +341,13 @@
           },
           "title": "List of Common Platform Enumeration identifiers associated with this component"
         },
-        "error_message": {
+        "info_message": {
           "type": "string",
-          "title": "Optional error message describing what went wrong during component processing"
+          "description": "Status message describing the outcome of processing this component.\nReplaces the removed `error_message` field (position 5)."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode",
-          "title": "Optional error code indicating the type of error encountered"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\nReplaces the removed `error_code` field (position 6).\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No CPE information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "description": "Common Platform Enumeration information for a specific component.\n\nContains CPE identifiers that can be used to match the component\nagainst vulnerability databases and security advisories."
@@ -378,7 +378,7 @@
           "title": "Response status indicating success or failure"
         }
       },
-      "description": "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"cpes\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}"
+      "description": "Success example. For error cases, each component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"cpes\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}"
     },
     "v2ComponentRequest": {
       "type": "object",
@@ -423,13 +423,13 @@
           },
           "title": "List of known vulnerabilities affecting this component"
         },
-        "error_message": {
+        "info_message": {
           "type": "string",
-          "title": "Optional error message describing what went wrong during component processing"
+          "description": "Status message describing the outcome of processing this component.\nReplaces the removed `error_message` field (position 5)."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode",
-          "title": "Optional error code indicating the type of error encountered"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\nReplaces the removed `error_code` field (position 6).\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No vulnerability information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "description": "Vulnerability information for a specific component identified by PURL and version.\n\nContains comprehensive vulnerability details including CVE information, severity scores,\nand security metadata for software components."
@@ -480,7 +480,7 @@
           "title": "Response status indicating success or failure"
         }
       },
-      "description": "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"error_message\":\"Component not found in database\",\"error_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}"
+      "description": "Success example. For error cases, the component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}"
     },
     "v2ComponentsCpesResponse": {
       "type": "object",
@@ -522,7 +522,7 @@
           "title": "Response status indicating success or failure"
         }
       },
-      "description": "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"components\\\":[{\\\"purl\\\":\\\"pkg:github/scanoss/engine\\\",\\\"requirement\\\":\\\"1.0.0\\\",\\\"version\\\":\\\"1.0.0\\\",\\\"cpes\\\":[\\\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\\\"]},{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"requirement\\\":\\\"\\\",\\\"version\\\":\\\"\\\",\\\"cpes\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"}],\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}"
+      "description": "Success example. For error cases, each component block reports the processing status via info_message and info_code. Example: {\"components\":[{\"purl\":\"pkg:github/scanoss/engine\",\"requirement\":\"1.0.0\",\"version\":\"1.0.0\",\"cpes\":[\"cpe:2.3:a:scanoss:engine:1.0.0:*:*:*:*:*:*:*\"]},{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"cpes\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}"
     },
     "v2ComponentsRequest": {
       "type": "object",
@@ -631,7 +631,7 @@
           "title": "Response status indicating success or failure"
         }
       },
-      "description": "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\"components\":[{\"purl\":\"pkg:github/scanoss/engine\",\"requirement\":\"1.0.0\",\"version\":\"1.0.0\",\"vulnerabilities\":[{\"id\":\"CVE-1999-0214\",\"cve\":\"CVE-1999-0214\"}]},{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"error_message\":\"Component not found in database\",\"error_code\":\"COMPONENT_NOT_FOUND\"}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}"
+      "description": "Success example. For error cases, each component block reports the processing status via info_message and info_code. Example: {\"components\":[{\"purl\":\"pkg:github/scanoss/engine\",\"requirement\":\"1.0.0\",\"version\":\"1.0.0\",\"vulnerabilities\":[{\"id\":\"CVE-1999-0214\",\"cve\":\"CVE-1999-0214\"}]},{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\",\"version\":\"\",\"vulnerabilities\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"}],\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}"
     },
     "v2CpeResponse": {
       "type": "object",
@@ -701,19 +701,6 @@
         }
       },
       "description": "Echo Message Response."
-    },
-    "v2ErrorCode": {
-      "type": "string",
-      "enum": [
-        "INVALID_PURL",
-        "COMPONENT_NOT_FOUND",
-        "NO_INFO",
-        "INVALID_SEMVER",
-        "VERSION_NOT_FOUND",
-        "TOO_MANY_CONTRIBUTORS"
-      ],
-      "default": "INVALID_PURL",
-      "description": "Error code enum for component analysis operations.\nRepresents the various error conditions that can occur during component processing and validation.\n\n - INVALID_PURL: The provided Package URL (PURL) is invalid or malformed\n - COMPONENT_NOT_FOUND: The requested component could not be found in the database\n - NO_INFO: No information is available for the requested component\n - INVALID_SEMVER: The provided semantic version (SemVer) is invalid or malformed\n - VERSION_NOT_FOUND: Component version not found\n - TOO_MANY_CONTRIBUTORS: Too many contributors for a component. Used by Geoprovenance service"
     },
     "v2StatusCode": {
       "type": "string",


### PR DESCRIPTION
…info_message/info_code vulnerability response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Component-level fields in vulnerability responses have been renamed: `error_message` and `error_code` are now `info_message` and `info_code`. New possible info_code values include `INVALID_PURL`, `COMPONENT_NOT_FOUND`, `NO_INFO`, `INVALID_SEMVER`, and `VERSION_NOT_FOUND`. Clients must update to use the new field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->