### PR TITLE
chore(cryptography):SP-4324 replace error_message/error_code witn inf…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ## [0.41.0] - 2026-04-20
 ### Added
 - Added `info_message` and `info_code` fields to all Cryptography response messages (`AlgorithmResponse.Purls`, `ComponentAlgorithms`, `AlgorithmsInRangeResponse.Purl`, `ComponentsAlgorithmsInRangeResponse.Component`, `ComponentAlgorithmsInRangeResponse.Component`, `VersionsInRangeResponse.Purl`, `ComponentsVersionsInRangeResponse.Component`, `ComponentVersionsInRangeResponse.Component`, `ComponentHints`, `HintsResponse.Purls`, `HintsInRangeResponse.Purl`, `ComponentsHintsInRangeResponse.Component`, `ComponentHintsInRangeResponse.Component`)
 ### Removed
 - **Breaking change:** Removed `error_message` and `error_code` fields from all Cryptography response messages. Clients must migrate to `info_message`/`info_code`
+### Changed
+- Cleaned up `info_message`/`info_code` field descriptions across Vulnerability, Dependency, License and Cryptography protos, swagger definitions and generated Go code; removed per-service breaking-change blockquotes from their READMEs (history kept in this changelog)
+
 
 ## [0.40.0] - 2026-04-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-04-20
+### Added
+- Added `info_message` and `info_code` fields to all Cryptography response messages (`AlgorithmResponse.Purls`, `ComponentAlgorithms`, `AlgorithmsInRangeResponse.Purl`, `ComponentsAlgorithmsInRangeResponse.Component`, `ComponentAlgorithmsInRangeResponse.Component`, `VersionsInRangeResponse.Purl`, `ComponentsVersionsInRangeResponse.Component`, `ComponentVersionsInRangeResponse.Component`, `ComponentHints`, `HintsResponse.Purls`, `HintsInRangeResponse.Purl`, `ComponentsHintsInRangeResponse.Component`, `ComponentHintsInRangeResponse.Component`)
+### Removed
+- **Breaking change:** Removed `error_message` and `error_code` fields from all Cryptography response messages. Clients must migrate to `info_message`/`info_code`
+
 ## [0.40.0] - 2026-04-17
 ### Added
 - Added `info_message` and `info_code` fields to `ComponentVulnerabilityInfo` and `ComponentCpesInfo` messages in Vulnerability responses as the definitive fields for reporting the outcome of processing each component
@@ -299,6 +305,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Vulnerabilities
 - Added REST endpoint support for each service also
 
+[0.41.0]: https://github.com/scanoss/papi/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/scanoss/papi/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/scanoss/papi/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/scanoss/papi/compare/v0.37.0...v0.38.0

--- a/api/cryptographyv2/scanoss-cryptography.pb.go
+++ b/api/cryptographyv2/scanoss-cryptography.pb.go
@@ -186,9 +186,18 @@ type ComponentAlgorithms struct {
 	// Echoes the client's version constraint from the request. See Common API Types documentation for resolution logic
 	Requirement string `protobuf:"bytes,3,opt,name=requirement,proto3" json:"requirement,omitempty"`
 	// List of cryptographic algorithms detected in this component version
-	Algorithms    []*Algorithm        `protobuf:"bytes,4,rep,name=algorithms,proto3" json:"algorithms,omitempty"`
-	ErrorMessage  *string             `protobuf:"bytes,5,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,6,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	Algorithms []*Algorithm `protobuf:"bytes,4,rep,name=algorithms,proto3" json:"algorithms,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,7,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	//   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+	//   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+	InfoCode      *string `protobuf:"bytes,8,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -251,18 +260,18 @@ func (x *ComponentAlgorithms) GetAlgorithms() []*Algorithm {
 	return nil
 }
 
-func (x *ComponentAlgorithms) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentAlgorithms) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentAlgorithms) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentAlgorithms) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Response message for GetComponentsAlgorithms method.
@@ -833,9 +842,18 @@ type ComponentHints struct {
 	// Echoes the client's version constraint from the request. See Common API Types documentation for resolution logic
 	Requirement string `protobuf:"bytes,3,opt,name=requirement,proto3" json:"requirement,omitempty"`
 	// List of cryptographic hints detected in this component version
-	Hints         []*Hint             `protobuf:"bytes,4,rep,name=hints,proto3" json:"hints,omitempty"`
-	ErrorMessage  *string             `protobuf:"bytes,5,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,6,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	Hints []*Hint `protobuf:"bytes,4,rep,name=hints,proto3" json:"hints,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,7,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	//   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+	//   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+	InfoCode      *string `protobuf:"bytes,8,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -898,18 +916,18 @@ func (x *ComponentHints) GetHints() []*Hint {
 	return nil
 }
 
-func (x *ComponentHints) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentHints) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentHints) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentHints) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Encryption Hints response data
@@ -1325,9 +1343,18 @@ type AlgorithmResponse_Purls struct {
 	// Specific version of the component that was analyzed
 	Version string `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
 	// List of cryptographic algorithms detected in this component version
-	Algorithms    []*Algorithm        `protobuf:"bytes,3,rep,name=algorithms,proto3" json:"algorithms,omitempty"`
-	ErrorMessage  *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	Algorithms []*Algorithm `protobuf:"bytes,3,rep,name=algorithms,proto3" json:"algorithms,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	//   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+	//   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1383,18 +1410,18 @@ func (x *AlgorithmResponse_Purls) GetAlgorithms() []*Algorithm {
 	return nil
 }
 
-func (x *AlgorithmResponse_Purls) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *AlgorithmResponse_Purls) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *AlgorithmResponse_Purls) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *AlgorithmResponse_Purls) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Information for a given PURL
@@ -1405,9 +1432,16 @@ type AlgorithmsInRangeResponse_Purl struct {
 	// List of versions in that range that contains cryptography
 	Versions []string `protobuf:"bytes,2,rep,name=versions,proto3" json:"versions,omitempty"`
 	// Algorithms list detected in that range
-	Algorithms    []*Algorithm        `protobuf:"bytes,3,rep,name=algorithms,proto3" json:"algorithms,omitempty"`
-	ErrorMessage  *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	Algorithms []*Algorithm `protobuf:"bytes,3,rep,name=algorithms,proto3" json:"algorithms,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1463,18 +1497,18 @@ func (x *AlgorithmsInRangeResponse_Purl) GetAlgorithms() []*Algorithm {
 	return nil
 }
 
-func (x *AlgorithmsInRangeResponse_Purl) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *AlgorithmsInRangeResponse_Purl) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *AlgorithmsInRangeResponse_Purl) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *AlgorithmsInRangeResponse_Purl) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Algorithm information for a specific component across version ranges.
@@ -1485,9 +1519,16 @@ type ComponentsAlgorithmsInRangeResponse_Component struct {
 	// List of versions in the specified range that contain cryptographic algorithms
 	Versions []string `protobuf:"bytes,2,rep,name=versions,proto3" json:"versions,omitempty"`
 	// List of cryptographic algorithms detected across the version range
-	Algorithms    []*Algorithm        `protobuf:"bytes,3,rep,name=algorithms,proto3" json:"algorithms,omitempty"`
-	ErrorMessage  *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	Algorithms []*Algorithm `protobuf:"bytes,3,rep,name=algorithms,proto3" json:"algorithms,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1543,18 +1584,18 @@ func (x *ComponentsAlgorithmsInRangeResponse_Component) GetAlgorithms() []*Algor
 	return nil
 }
 
-func (x *ComponentsAlgorithmsInRangeResponse_Component) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentsAlgorithmsInRangeResponse_Component) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentsAlgorithmsInRangeResponse_Component) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentsAlgorithmsInRangeResponse_Component) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Algorithm information for a specific component across version ranges.
@@ -1565,9 +1606,16 @@ type ComponentAlgorithmsInRangeResponse_Component struct {
 	// List of versions in the specified range that contain cryptographic algorithms
 	Versions []string `protobuf:"bytes,2,rep,name=versions,proto3" json:"versions,omitempty"`
 	// List of cryptographic algorithms detected across the version range
-	Algorithms    []*Algorithm        `protobuf:"bytes,3,rep,name=algorithms,proto3" json:"algorithms,omitempty"`
-	ErrorMessage  *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	Algorithms []*Algorithm `protobuf:"bytes,3,rep,name=algorithms,proto3" json:"algorithms,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1623,18 +1671,18 @@ func (x *ComponentAlgorithmsInRangeResponse_Component) GetAlgorithms() []*Algori
 	return nil
 }
 
-func (x *ComponentAlgorithmsInRangeResponse_Component) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentAlgorithmsInRangeResponse_Component) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentAlgorithmsInRangeResponse_Component) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentAlgorithmsInRangeResponse_Component) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Information for a given PURL
@@ -1645,11 +1693,18 @@ type VersionsInRangeResponse_Purl struct {
 	// List of versions that contains cryptography
 	VersionsWith []string `protobuf:"bytes,2,rep,name=versions_with,proto3" json:"versions_with,omitempty"`
 	// List of versions that do not contain cryptography
-	VersionsWithout []string            `protobuf:"bytes,3,rep,name=versions_without,proto3" json:"versions_without,omitempty"`
-	ErrorMessage    *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode       *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	VersionsWithout []string `protobuf:"bytes,3,rep,name=versions_without,proto3" json:"versions_without,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *VersionsInRangeResponse_Purl) Reset() {
@@ -1703,18 +1758,18 @@ func (x *VersionsInRangeResponse_Purl) GetVersionsWithout() []string {
 	return nil
 }
 
-func (x *VersionsInRangeResponse_Purl) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *VersionsInRangeResponse_Purl) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *VersionsInRangeResponse_Purl) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *VersionsInRangeResponse_Purl) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Version information for a specific component categorized by cryptographic presence.
@@ -1725,11 +1780,18 @@ type ComponentsVersionsInRangeResponse_Component struct {
 	// List of versions in the specified range that contain cryptographic algorithms
 	VersionsWith []string `protobuf:"bytes,2,rep,name=versions_with,proto3" json:"versions_with,omitempty"`
 	// List of versions in the specified range that do not contain cryptographic algorithms
-	VersionsWithout []string            `protobuf:"bytes,3,rep,name=versions_without,proto3" json:"versions_without,omitempty"`
-	ErrorMessage    *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode       *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	VersionsWithout []string `protobuf:"bytes,3,rep,name=versions_without,proto3" json:"versions_without,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ComponentsVersionsInRangeResponse_Component) Reset() {
@@ -1783,18 +1845,18 @@ func (x *ComponentsVersionsInRangeResponse_Component) GetVersionsWithout() []str
 	return nil
 }
 
-func (x *ComponentsVersionsInRangeResponse_Component) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentsVersionsInRangeResponse_Component) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentsVersionsInRangeResponse_Component) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentsVersionsInRangeResponse_Component) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Version information for a specific component categorized by cryptographic presence.
@@ -1805,11 +1867,18 @@ type ComponentVersionsInRangeResponse_Component struct {
 	// List of versions in the specified range that contain cryptographic algorithms
 	VersionsWith []string `protobuf:"bytes,2,rep,name=versions_with,proto3" json:"versions_with,omitempty"`
 	// List of versions in the specified range that do not contain cryptographic algorithms
-	VersionsWithout []string            `protobuf:"bytes,3,rep,name=versions_without,proto3" json:"versions_without,omitempty"`
-	ErrorMessage    *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode       *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	VersionsWithout []string `protobuf:"bytes,3,rep,name=versions_without,proto3" json:"versions_without,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ComponentVersionsInRangeResponse_Component) Reset() {
@@ -1863,18 +1932,18 @@ func (x *ComponentVersionsInRangeResponse_Component) GetVersionsWithout() []stri
 	return nil
 }
 
-func (x *ComponentVersionsInRangeResponse_Component) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentVersionsInRangeResponse_Component) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentVersionsInRangeResponse_Component) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentVersionsInRangeResponse_Component) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Information for a given purl
@@ -1885,9 +1954,18 @@ type HintsResponse_Purls struct {
 	// PURL version
 	Version string `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
 	// Algorithms list detected for that version
-	Hints         []*Hint             `protobuf:"bytes,3,rep,name=hints,proto3" json:"hints,omitempty"`
-	ErrorMessage  *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	Hints []*Hint `protobuf:"bytes,3,rep,name=hints,proto3" json:"hints,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	//   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+	//   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1943,18 +2021,18 @@ func (x *HintsResponse_Purls) GetHints() []*Hint {
 	return nil
 }
 
-func (x *HintsResponse_Purls) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *HintsResponse_Purls) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *HintsResponse_Purls) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *HintsResponse_Purls) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Information about the requested purl
@@ -1965,9 +2043,16 @@ type HintsInRangeResponse_Purl struct {
 	// List of versions in range
 	Versions []string `protobuf:"bytes,2,rep,name=versions,proto3" json:"versions,omitempty"`
 	// Encryption hints
-	Hints         []*Hint             `protobuf:"bytes,3,rep,name=hints,proto3" json:"hints,omitempty"`
-	ErrorMessage  *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	Hints []*Hint `protobuf:"bytes,3,rep,name=hints,proto3" json:"hints,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2023,18 +2108,18 @@ func (x *HintsInRangeResponse_Purl) GetHints() []*Hint {
 	return nil
 }
 
-func (x *HintsInRangeResponse_Purl) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *HintsInRangeResponse_Purl) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *HintsInRangeResponse_Purl) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *HintsInRangeResponse_Purl) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Information about the requested purl
@@ -2045,9 +2130,16 @@ type ComponentsHintsInRangeResponse_Component struct {
 	// List of versions in range
 	Versions []string `protobuf:"bytes,2,rep,name=versions,proto3" json:"versions,omitempty"`
 	// Encryption hints
-	Hints         []*Hint             `protobuf:"bytes,3,rep,name=hints,proto3" json:"hints,omitempty"`
-	ErrorMessage  *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	Hints []*Hint `protobuf:"bytes,3,rep,name=hints,proto3" json:"hints,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2103,18 +2195,18 @@ func (x *ComponentsHintsInRangeResponse_Component) GetHints() []*Hint {
 	return nil
 }
 
-func (x *ComponentsHintsInRangeResponse_Component) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentsHintsInRangeResponse_Component) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentsHintsInRangeResponse_Component) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentsHintsInRangeResponse_Component) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Information about the requested purl
@@ -2125,9 +2217,16 @@ type ComponentHintsInRangeResponse_Component struct {
 	// List of versions in range
 	Versions []string `protobuf:"bytes,2,rep,name=versions,proto3" json:"versions,omitempty"`
 	// Encryption hints
-	Hints         []*Hint             `protobuf:"bytes,3,rep,name=hints,proto3" json:"hints,omitempty"`
-	ErrorMessage  *string             `protobuf:"bytes,4,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,5,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	Hints []*Hint `protobuf:"bytes,3,rep,name=hints,proto3" json:"hints,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,6,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No cryptography information is available for the requested component.
+	InfoCode      *string `protobuf:"bytes,7,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2183,18 +2282,18 @@ func (x *ComponentHintsInRangeResponse_Component) GetHints() []*Hint {
 	return nil
 }
 
-func (x *ComponentHintsInRangeResponse_Component) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentHintsInRangeResponse_Component) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentHintsInRangeResponse_Component) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentHintsInRangeResponse_Component) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 var File_scanoss_api_cryptography_v2_scanoss_cryptography_proto protoreflect.FileDescriptor
@@ -2204,136 +2303,136 @@ const file_scanoss_api_cryptography_v2_scanoss_cryptography_proto_rawDesc = "" +
 	"6scanoss/api/cryptography/v2/scanoss-cryptography.proto\x12\x1bscanoss.api.cryptography.v2\x1a*scanoss/api/common/v2/scanoss-common.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x19google/api/httpbody.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"E\n" +
 	"\tAlgorithm\x12\x1c\n" +
 	"\talgorithm\x18\x01 \x01(\tR\talgorithm\x12\x1a\n" +
-	"\bstrength\x18\x02 \x01(\tR\bstrength\"\xb5\x03\n" +
+	"\bstrength\x18\x02 \x01(\tR\bstrength\"\xb4\x03\n" +
 	"\x11AlgorithmResponse\x12J\n" +
 	"\x05purls\x18\x01 \x03(\v24.scanoss.api.cryptography.v2.AlgorithmResponse.PurlsR\x05purls\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x90\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x8f\x02\n" +
 	"\x05Purls\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12F\n" +
 	"\n" +
 	"algorithms\x18\x03 \x03(\v2&.scanoss.api.cryptography.v2.AlgorithmR\n" +
-	"algorithms\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"algorithms\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code:\x02\x18\x01\"\xc0\x02\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code:\x02\x18\x01\"\xbf\x02\n" +
 	"\x13ComponentAlgorithms\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12 \n" +
 	"\vrequirement\x18\x03 \x01(\tR\vrequirement\x12F\n" +
 	"\n" +
 	"algorithms\x18\x04 \x03(\v2&.scanoss.api.cryptography.v2.AlgorithmR\n" +
-	"algorithms\x12)\n" +
-	"\rerror_message\x18\x05 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"algorithms\x12'\n" +
+	"\finfo_message\x18\a \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\b \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x06 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code\"\x8d\x05\n" +
+	"_info_codeJ\x04\b\x05\x10\x06J\x04\b\x06\x10\aR\rerror_messageR\n" +
+	"error_code\"\x8b\x05\n" +
 	"\x1cComponentsAlgorithmsResponse\x12P\n" +
 	"\n" +
 	"components\x18\x01 \x03(\v20.scanoss.api.cryptography.v2.ComponentAlgorithmsR\n" +
 	"components\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xdb\x03\x92A\xd7\x03\n" +
-	"\xd4\x03J\xd1\x03{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \">=5.0.0\", \"version\": \"5.0.0\", \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}, {\"algorithm\": \"RSA\", \"strength\": \"Strong\"}]}, {\"purl\": \"pkg:github/unknown/component\", \"requirement\": \">=1.0.0\", \"version\": \"\", \"algorithms\": [], \"error_message\": \"Component not found in database\", \"error_code\": \"COMPONENT_NOT_FOUND\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Batch request processed\"}}\"\xd9\x06\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xd9\x03\x92A\xd5\x03\n" +
+	"\xd2\x03J\xcf\x03{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \">=5.0.0\", \"version\": \"5.0.0\", \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}, {\"algorithm\": \"RSA\", \"strength\": \"Strong\"}]}, {\"purl\": \"pkg:github/unknown/component\", \"requirement\": \">=1.0.0\", \"version\": \"\", \"algorithms\": [], \"info_message\": \"Component not found in database\", \"info_code\": \"COMPONENT_NOT_FOUND\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Batch request processed\"}}\"\xcc\x06\n" +
 	"\x1bComponentAlgorithmsResponse\x12N\n" +
 	"\tcomponent\x18\x01 \x01(\v20.scanoss.api.cryptography.v2.ComponentAlgorithmsR\tcomponent\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\xaa\x05\x92A\xa6\x05\n" +
-	"\xa3\x052\x83\x03Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"requirement\\\":\\\">=1.0.0\\\",\\\"version\\\":\\\"\\\",\\\"algorithms\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}J\x9a\x02{\"component\":{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \">=5.0.0\", \"version\": \"5.0.0\", \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}, {\"algorithm\": \"RSA\", \"strength\": \"Strong\"}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Algorithms Successfully retrieved\"}}\"\xc5\x03\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status:\x9d\x05\x92A\x99\x05\n" +
+	"\x96\x052\xf6\x02Success example. For error cases, the component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\">=1.0.0\",\"version\":\"\",\"algorithms\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}J\x9a\x02{\"component\":{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \">=5.0.0\", \"version\": \"5.0.0\", \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}, {\"algorithm\": \"RSA\", \"strength\": \"Strong\"}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Algorithms Successfully retrieved\"}}\"\xc4\x03\n" +
 	"\x19AlgorithmsInRangeResponse\x12Q\n" +
 	"\x05purls\x18\x01 \x03(\v2;.scanoss.api.cryptography.v2.AlgorithmsInRangeResponse.PurlR\x05purls\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x91\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x90\x02\n" +
 	"\x04Purl\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x1a\n" +
 	"\bversions\x18\x02 \x03(\tR\bversions\x12F\n" +
 	"\n" +
 	"algorithms\x18\x03 \x03(\v2&.scanoss.api.cryptography.v2.AlgorithmR\n" +
-	"algorithms\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"algorithms\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code:\x02\x18\x01\"\xe6\x06\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code:\x02\x18\x01\"\xe5\x06\n" +
 	"#ComponentsAlgorithmsInRangeResponse\x12j\n" +
 	"\n" +
 	"components\x18\x01 \x03(\v2J.scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse.ComponentR\n" +
 	"components\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x96\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x95\x02\n" +
 	"\tComponent\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x1a\n" +
 	"\bversions\x18\x02 \x03(\tR\bversions\x12F\n" +
 	"\n" +
 	"algorithms\x18\x03 \x03(\v2&.scanoss.api.cryptography.v2.AlgorithmR\n" +
-	"algorithms\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"algorithms\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code:\xfa\x02\x92A\xf6\x02\n" +
-	"\xf3\x02J\xf0\x02{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"1.0.0\", \"2.0.0\"], \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\", \"versions\": [\"v1.30.0\"], \"algorithms\": [{\"algorithm\": \"SHA-256\", \"strength\": \"Strong\"}]}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Algorithms in range Successfully retrieved\"}}\"\x91\x06\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code:\xfa\x02\x92A\xf6\x02\n" +
+	"\xf3\x02J\xf0\x02{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"1.0.0\", \"2.0.0\"], \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\", \"versions\": [\"v1.30.0\"], \"algorithms\": [{\"algorithm\": \"SHA-256\", \"strength\": \"Strong\"}]}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Algorithms in range Successfully retrieved\"}}\"\x90\x06\n" +
 	"\"ComponentAlgorithmsInRangeResponse\x12g\n" +
 	"\tcomponent\x18\x01 \x01(\v2I.scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse.ComponentR\tcomponent\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x96\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x95\x02\n" +
 	"\tComponent\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x1a\n" +
 	"\bversions\x18\x02 \x03(\tR\bversions\x12F\n" +
 	"\n" +
 	"algorithms\x18\x03 \x03(\v2&.scanoss.api.cryptography.v2.AlgorithmR\n" +
-	"algorithms\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"algorithms\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code:\xa9\x02\x92A\xa5\x02\n" +
-	"\xa2\x02J\x9f\x02{\"component\": {\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"1.0.0\", \"2.0.0\", \"3.0.0\"], \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}, {\"algorithm\": \"RSA\", \"strength\": \"Strong\"}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Algorithms in range Successfully retrieved\"}}\"\xaf\x03\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code:\xa9\x02\x92A\xa5\x02\n" +
+	"\xa2\x02J\x9f\x02{\"component\": {\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"1.0.0\", \"2.0.0\", \"3.0.0\"], \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}, {\"algorithm\": \"RSA\", \"strength\": \"Strong\"}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Algorithms in range Successfully retrieved\"}}\"\xae\x03\n" +
 	"\x17VersionsInRangeResponse\x12O\n" +
 	"\x05purls\x18\x01 \x03(\v29.scanoss.api.cryptography.v2.VersionsInRangeResponse.PurlR\x05purls\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\xff\x01\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\xfe\x01\n" +
 	"\x04Purl\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12$\n" +
 	"\rversions_with\x18\x02 \x03(\tR\rversions_with\x12*\n" +
-	"\x10versions_without\x18\x03 \x03(\tR\x10versions_without\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x10versions_without\x18\x03 \x03(\tR\x10versions_without\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code:\x02\x18\x01\"\x99\x06\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code:\x02\x18\x01\"\x98\x06\n" +
 	"!ComponentsVersionsInRangeResponse\x12h\n" +
 	"\n" +
 	"components\x18\x01 \x03(\v2H.scanoss.api.cryptography.v2.ComponentsVersionsInRangeResponse.ComponentR\n" +
 	"components\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x84\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x83\x02\n" +
 	"\tComponent\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12$\n" +
 	"\rversions_with\x18\x02 \x03(\tR\rversions_with\x12*\n" +
-	"\x10versions_without\x18\x03 \x03(\tR\x10versions_without\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x10versions_without\x18\x03 \x03(\tR\x10versions_without\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code:\xc3\x02\x92A\xbf\x02\n" +
-	"\xbc\x02J\xb9\x02{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"versions_with\": [\"2.0.0\", \"3.0.0\"], \"versions_without\": [\"1.0.0\"]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\", \"versions_with\": [\"v1.30.0\"], \"versions_without\": [\"v1.29.0\"]}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Version ranges Successfully retrieved\"}}\"\xbb\x05\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code:\xc3\x02\x92A\xbf\x02\n" +
+	"\xbc\x02J\xb9\x02{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"versions_with\": [\"2.0.0\", \"3.0.0\"], \"versions_without\": [\"1.0.0\"]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\", \"versions_with\": [\"v1.30.0\"], \"versions_without\": [\"v1.29.0\"]}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Version ranges Successfully retrieved\"}}\"\xba\x05\n" +
 	" ComponentVersionsInRangeResponse\x12e\n" +
 	"\tcomponent\x18\x01 \x01(\v2G.scanoss.api.cryptography.v2.ComponentVersionsInRangeResponse.ComponentR\tcomponent\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x84\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x83\x02\n" +
 	"\tComponent\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12$\n" +
 	"\rversions_with\x18\x02 \x03(\tR\rversions_with\x12*\n" +
-	"\x10versions_without\x18\x03 \x03(\tR\x10versions_without\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x10versions_without\x18\x03 \x03(\tR\x10versions_without\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code:\xe9\x01\x92A\xe5\x01\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code:\xe9\x01\x92A\xe5\x01\n" +
 	"\xe2\x01J\xdf\x01{\"component\": {\"purl\": \"pkg:github/scanoss/engine\", \"versions_with\": [\"2.0.0\", \"3.0.0\", \"4.0.0\"], \"versions_without\": [\"1.0.0\", \"1.5.0\"]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Version ranges Successfully retrieved\"}}\"\x8e\x01\n" +
 	"\x04Hint\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
@@ -2341,74 +2440,74 @@ const file_scanoss_api_cryptography_v2_scanoss_cryptography_proto_rawDesc = "" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x12\x1a\n" +
 	"\bcategory\x18\x04 \x01(\tR\bcategory\x12\x10\n" +
 	"\x03url\x18\x05 \x01(\tR\x03url\x12\x12\n" +
-	"\x04purl\x18\x06 \x01(\tR\x04purl\"\xac\x02\n" +
+	"\x04purl\x18\x06 \x01(\tR\x04purl\"\xab\x02\n" +
 	"\x0eComponentHints\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12 \n" +
 	"\vrequirement\x18\x03 \x01(\tR\vrequirement\x127\n" +
-	"\x05hints\x18\x04 \x03(\v2!.scanoss.api.cryptography.v2.HintR\x05hints\x12)\n" +
-	"\rerror_message\x18\x05 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x05hints\x18\x04 \x03(\v2!.scanoss.api.cryptography.v2.HintR\x05hints\x12'\n" +
+	"\finfo_message\x18\a \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\b \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x06 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code\"\x9a\x03\n" +
+	"_info_codeJ\x04\b\x05\x10\x06J\x04\b\x06\x10\aR\rerror_messageR\n" +
+	"error_code\"\x99\x03\n" +
 	"\rHintsResponse\x12F\n" +
 	"\x05purls\x18\x01 \x03(\v20.scanoss.api.cryptography.v2.HintsResponse.PurlsR\x05purls\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x81\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x80\x02\n" +
 	"\x05Purls\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x127\n" +
-	"\x05hints\x18\x03 \x03(\v2!.scanoss.api.cryptography.v2.HintR\x05hints\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x05hints\x18\x03 \x03(\v2!.scanoss.api.cryptography.v2.HintR\x05hints\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code\"\xa8\x03\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code\"\xa7\x03\n" +
 	"\x14HintsInRangeResponse\x12L\n" +
 	"\x05purls\x18\x01 \x03(\v26.scanoss.api.cryptography.v2.HintsInRangeResponse.PurlR\x05purls\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x82\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x81\x02\n" +
 	"\x04Purl\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x1a\n" +
 	"\bversions\x18\x02 \x03(\tR\bversions\x127\n" +
-	"\x05hints\x18\x03 \x03(\v2!.scanoss.api.cryptography.v2.HintR\x05hints\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x05hints\x18\x03 \x03(\v2!.scanoss.api.cryptography.v2.HintR\x05hints\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code\"\xfd\a\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code\"\xfa\a\n" +
 	"\x1eComponentsHintsInRangeResponse\x12e\n" +
 	"\n" +
 	"components\x18\x01 \x03(\v2E.scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.ComponentR\n" +
 	"components\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x87\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x86\x02\n" +
 	"\tComponent\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x1a\n" +
 	"\bversions\x18\x02 \x03(\tR\bversions\x127\n" +
-	"\x05hints\x18\x03 \x03(\v2!.scanoss.api.cryptography.v2.HintR\x05hints\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x05hints\x18\x03 \x03(\v2!.scanoss.api.cryptography.v2.HintR\x05hints\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code:\xaa\x04\x92A\xa6\x04\n" +
-	"\xa3\x04J\xa0\x04{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"5.0.0\", \"5.1.0\"], \"hints\": [{\"id\": \"openssl-hint-001\", \"name\": \"OpenSSL\", \"description\": \"Industry standard cryptographic library\", \"category\": \"library\", \"url\": \"https://www.openssl.org/\", \"purl\": \"pkg:generic/openssl@3.0.0\"}]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\", \"versions\": [], \"hints\": [], \"error_message\": \"Component not found in database\", \"error_code\": \"COMPONENT_NOT_FOUND\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Cryptographic hints in range retrieved\"}}\"\xc3\t\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code:\xa8\x04\x92A\xa4\x04\n" +
+	"\xa1\x04J\x9e\x04{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"5.0.0\", \"5.1.0\"], \"hints\": [{\"id\": \"openssl-hint-001\", \"name\": \"OpenSSL\", \"description\": \"Industry standard cryptographic library\", \"category\": \"library\", \"url\": \"https://www.openssl.org/\", \"purl\": \"pkg:generic/openssl@3.0.0\"}]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\", \"versions\": [], \"hints\": [], \"info_message\": \"Component not found in database\", \"info_code\": \"COMPONENT_NOT_FOUND\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Cryptographic hints in range retrieved\"}}\"\xbb\t\n" +
 	"\x1dComponentHintsInRangeResponse\x12b\n" +
 	"\tcomponent\x18\x01 \x01(\v2D.scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.ComponentR\tcomponent\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x87\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x86\x02\n" +
 	"\tComponent\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x1a\n" +
 	"\bversions\x18\x02 \x03(\tR\bversions\x127\n" +
-	"\x05hints\x18\x03 \x03(\v2!.scanoss.api.cryptography.v2.HintR\x05hints\x12)\n" +
-	"\rerror_message\x18\x04 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x05hints\x18\x03 \x03(\v2!.scanoss.api.cryptography.v2.HintR\x05hints\x12'\n" +
+	"\finfo_message\x18\x06 \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\a \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\x05 \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code:\xf4\x05\x92A\xf0\x05\n" +
-	"\xed\x052\xe1\x02Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"versions\\\":[],\\\"hints\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}J\x86\x03{\"component\": {\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"5.0.0\", \"5.1.0\", \"5.2.0\"], \"hints\": [{\"id\": \"openssl-hint-001\", \"name\": \"OpenSSL\", \"description\": \"Industry standard cryptographic library\", \"category\": \"library\", \"url\": \"https://www.openssl.org/\", \"purl\": \"pkg:generic/openssl@3.0.0\"}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Cryptographic hints in range retrieved\"}}\"\xe8\x06\n" +
+	"_info_codeJ\x04\b\x04\x10\x05J\x04\b\x05\x10\x06R\rerror_messageR\n" +
+	"error_code:\xed\x05\x92A\xe9\x05\n" +
+	"\xe6\x052\xda\x02Success example. For error cases, the component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"versions\":[],\"hints\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}J\x86\x03{\"component\": {\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"5.0.0\", \"5.1.0\", \"5.2.0\"], \"hints\": [{\"id\": \"openssl-hint-001\", \"name\": \"OpenSSL\", \"description\": \"Industry standard cryptographic library\", \"category\": \"library\", \"url\": \"https://www.openssl.org/\", \"purl\": \"pkg:generic/openssl@3.0.0\"}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Cryptographic hints in range retrieved\"}}\"\xe8\x06\n" +
 	"!ComponentsEncryptionHintsResponse\x12K\n" +
 	"\n" +
 	"components\x18\x01 \x03(\v2+.scanoss.api.cryptography.v2.ComponentHintsR\n" +
@@ -2492,107 +2591,93 @@ var file_scanoss_api_cryptography_v2_scanoss_cryptography_proto_goTypes = []any{
 	(*ComponentsHintsInRangeResponse_Component)(nil),      // 29: scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.Component
 	(*ComponentHintsInRangeResponse_Component)(nil),       // 30: scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.Component
 	(*commonv2.StatusResponse)(nil),                       // 31: scanoss.api.common.v2.StatusResponse
-	(commonv2.ErrorCode)(0),                               // 32: scanoss.api.common.v2.ErrorCode
-	(*commonv2.EchoRequest)(nil),                          // 33: scanoss.api.common.v2.EchoRequest
-	(*commonv2.PurlRequest)(nil),                          // 34: scanoss.api.common.v2.PurlRequest
-	(*commonv2.ComponentRequest)(nil),                     // 35: scanoss.api.common.v2.ComponentRequest
-	(*commonv2.ComponentsRequest)(nil),                    // 36: scanoss.api.common.v2.ComponentsRequest
-	(*commonv2.EchoResponse)(nil),                         // 37: scanoss.api.common.v2.EchoResponse
-	(*httpbody.HttpBody)(nil),                             // 38: google.api.HttpBody
+	(*commonv2.EchoRequest)(nil),                          // 32: scanoss.api.common.v2.EchoRequest
+	(*commonv2.PurlRequest)(nil),                          // 33: scanoss.api.common.v2.PurlRequest
+	(*commonv2.ComponentRequest)(nil),                     // 34: scanoss.api.common.v2.ComponentRequest
+	(*commonv2.ComponentsRequest)(nil),                    // 35: scanoss.api.common.v2.ComponentsRequest
+	(*commonv2.EchoResponse)(nil),                         // 36: scanoss.api.common.v2.EchoResponse
+	(*httpbody.HttpBody)(nil),                             // 37: google.api.HttpBody
 }
 var file_scanoss_api_cryptography_v2_scanoss_cryptography_proto_depIdxs = []int32{
 	20, // 0: scanoss.api.cryptography.v2.AlgorithmResponse.purls:type_name -> scanoss.api.cryptography.v2.AlgorithmResponse.Purls
 	31, // 1: scanoss.api.cryptography.v2.AlgorithmResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
 	0,  // 2: scanoss.api.cryptography.v2.ComponentAlgorithms.algorithms:type_name -> scanoss.api.cryptography.v2.Algorithm
-	32, // 3: scanoss.api.cryptography.v2.ComponentAlgorithms.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	2,  // 4: scanoss.api.cryptography.v2.ComponentsAlgorithmsResponse.components:type_name -> scanoss.api.cryptography.v2.ComponentAlgorithms
-	31, // 5: scanoss.api.cryptography.v2.ComponentsAlgorithmsResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	2,  // 6: scanoss.api.cryptography.v2.ComponentAlgorithmsResponse.component:type_name -> scanoss.api.cryptography.v2.ComponentAlgorithms
-	31, // 7: scanoss.api.cryptography.v2.ComponentAlgorithmsResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	21, // 8: scanoss.api.cryptography.v2.AlgorithmsInRangeResponse.purls:type_name -> scanoss.api.cryptography.v2.AlgorithmsInRangeResponse.Purl
-	31, // 9: scanoss.api.cryptography.v2.AlgorithmsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	22, // 10: scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse.components:type_name -> scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse.Component
-	31, // 11: scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	23, // 12: scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse.component:type_name -> scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse.Component
-	31, // 13: scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	24, // 14: scanoss.api.cryptography.v2.VersionsInRangeResponse.purls:type_name -> scanoss.api.cryptography.v2.VersionsInRangeResponse.Purl
-	31, // 15: scanoss.api.cryptography.v2.VersionsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	25, // 16: scanoss.api.cryptography.v2.ComponentsVersionsInRangeResponse.components:type_name -> scanoss.api.cryptography.v2.ComponentsVersionsInRangeResponse.Component
-	31, // 17: scanoss.api.cryptography.v2.ComponentsVersionsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	26, // 18: scanoss.api.cryptography.v2.ComponentVersionsInRangeResponse.component:type_name -> scanoss.api.cryptography.v2.ComponentVersionsInRangeResponse.Component
-	31, // 19: scanoss.api.cryptography.v2.ComponentVersionsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	11, // 20: scanoss.api.cryptography.v2.ComponentHints.hints:type_name -> scanoss.api.cryptography.v2.Hint
-	32, // 21: scanoss.api.cryptography.v2.ComponentHints.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	27, // 22: scanoss.api.cryptography.v2.HintsResponse.purls:type_name -> scanoss.api.cryptography.v2.HintsResponse.Purls
-	31, // 23: scanoss.api.cryptography.v2.HintsResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	28, // 24: scanoss.api.cryptography.v2.HintsInRangeResponse.purls:type_name -> scanoss.api.cryptography.v2.HintsInRangeResponse.Purl
-	31, // 25: scanoss.api.cryptography.v2.HintsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	29, // 26: scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.components:type_name -> scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.Component
-	31, // 27: scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	30, // 28: scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.component:type_name -> scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.Component
-	31, // 29: scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	12, // 30: scanoss.api.cryptography.v2.ComponentsEncryptionHintsResponse.components:type_name -> scanoss.api.cryptography.v2.ComponentHints
-	31, // 31: scanoss.api.cryptography.v2.ComponentsEncryptionHintsResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	12, // 32: scanoss.api.cryptography.v2.ComponentEncryptionHintsResponse.component:type_name -> scanoss.api.cryptography.v2.ComponentHints
-	31, // 33: scanoss.api.cryptography.v2.ComponentEncryptionHintsResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
-	0,  // 34: scanoss.api.cryptography.v2.AlgorithmResponse.Purls.algorithms:type_name -> scanoss.api.cryptography.v2.Algorithm
-	32, // 35: scanoss.api.cryptography.v2.AlgorithmResponse.Purls.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	0,  // 36: scanoss.api.cryptography.v2.AlgorithmsInRangeResponse.Purl.algorithms:type_name -> scanoss.api.cryptography.v2.Algorithm
-	32, // 37: scanoss.api.cryptography.v2.AlgorithmsInRangeResponse.Purl.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	0,  // 38: scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse.Component.algorithms:type_name -> scanoss.api.cryptography.v2.Algorithm
-	32, // 39: scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse.Component.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	0,  // 40: scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse.Component.algorithms:type_name -> scanoss.api.cryptography.v2.Algorithm
-	32, // 41: scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse.Component.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	32, // 42: scanoss.api.cryptography.v2.VersionsInRangeResponse.Purl.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	32, // 43: scanoss.api.cryptography.v2.ComponentsVersionsInRangeResponse.Component.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	32, // 44: scanoss.api.cryptography.v2.ComponentVersionsInRangeResponse.Component.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	11, // 45: scanoss.api.cryptography.v2.HintsResponse.Purls.hints:type_name -> scanoss.api.cryptography.v2.Hint
-	32, // 46: scanoss.api.cryptography.v2.HintsResponse.Purls.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	11, // 47: scanoss.api.cryptography.v2.HintsInRangeResponse.Purl.hints:type_name -> scanoss.api.cryptography.v2.Hint
-	32, // 48: scanoss.api.cryptography.v2.HintsInRangeResponse.Purl.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	11, // 49: scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.Component.hints:type_name -> scanoss.api.cryptography.v2.Hint
-	32, // 50: scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.Component.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	11, // 51: scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.Component.hints:type_name -> scanoss.api.cryptography.v2.Hint
-	32, // 52: scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.Component.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	33, // 53: scanoss.api.cryptography.v2.Cryptography.Echo:input_type -> scanoss.api.common.v2.EchoRequest
-	34, // 54: scanoss.api.cryptography.v2.Cryptography.GetAlgorithms:input_type -> scanoss.api.common.v2.PurlRequest
-	35, // 55: scanoss.api.cryptography.v2.Cryptography.GetComponentAlgorithms:input_type -> scanoss.api.common.v2.ComponentRequest
-	36, // 56: scanoss.api.cryptography.v2.Cryptography.GetComponentsAlgorithms:input_type -> scanoss.api.common.v2.ComponentsRequest
-	34, // 57: scanoss.api.cryptography.v2.Cryptography.GetAlgorithmsInRange:input_type -> scanoss.api.common.v2.PurlRequest
-	35, // 58: scanoss.api.cryptography.v2.Cryptography.GetComponentAlgorithmsInRange:input_type -> scanoss.api.common.v2.ComponentRequest
-	36, // 59: scanoss.api.cryptography.v2.Cryptography.GetComponentsAlgorithmsInRange:input_type -> scanoss.api.common.v2.ComponentsRequest
-	34, // 60: scanoss.api.cryptography.v2.Cryptography.GetVersionsInRange:input_type -> scanoss.api.common.v2.PurlRequest
-	35, // 61: scanoss.api.cryptography.v2.Cryptography.GetComponentVersionsInRange:input_type -> scanoss.api.common.v2.ComponentRequest
-	36, // 62: scanoss.api.cryptography.v2.Cryptography.GetComponentsVersionsInRange:input_type -> scanoss.api.common.v2.ComponentsRequest
-	34, // 63: scanoss.api.cryptography.v2.Cryptography.GetHintsInRange:input_type -> scanoss.api.common.v2.PurlRequest
-	35, // 64: scanoss.api.cryptography.v2.Cryptography.GetComponentHintsInRange:input_type -> scanoss.api.common.v2.ComponentRequest
-	36, // 65: scanoss.api.cryptography.v2.Cryptography.GetComponentsHintsInRange:input_type -> scanoss.api.common.v2.ComponentsRequest
-	34, // 66: scanoss.api.cryptography.v2.Cryptography.GetEncryptionHints:input_type -> scanoss.api.common.v2.PurlRequest
-	35, // 67: scanoss.api.cryptography.v2.Cryptography.GetComponentEncryptionHints:input_type -> scanoss.api.common.v2.ComponentRequest
-	36, // 68: scanoss.api.cryptography.v2.Cryptography.GetComponentsEncryptionHints:input_type -> scanoss.api.common.v2.ComponentsRequest
-	19, // 69: scanoss.api.cryptography.v2.Cryptography.DownloadRuleset:input_type -> scanoss.api.cryptography.v2.RulesetDownloadRequest
-	37, // 70: scanoss.api.cryptography.v2.Cryptography.Echo:output_type -> scanoss.api.common.v2.EchoResponse
-	1,  // 71: scanoss.api.cryptography.v2.Cryptography.GetAlgorithms:output_type -> scanoss.api.cryptography.v2.AlgorithmResponse
-	4,  // 72: scanoss.api.cryptography.v2.Cryptography.GetComponentAlgorithms:output_type -> scanoss.api.cryptography.v2.ComponentAlgorithmsResponse
-	3,  // 73: scanoss.api.cryptography.v2.Cryptography.GetComponentsAlgorithms:output_type -> scanoss.api.cryptography.v2.ComponentsAlgorithmsResponse
-	5,  // 74: scanoss.api.cryptography.v2.Cryptography.GetAlgorithmsInRange:output_type -> scanoss.api.cryptography.v2.AlgorithmsInRangeResponse
-	7,  // 75: scanoss.api.cryptography.v2.Cryptography.GetComponentAlgorithmsInRange:output_type -> scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse
-	6,  // 76: scanoss.api.cryptography.v2.Cryptography.GetComponentsAlgorithmsInRange:output_type -> scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse
-	8,  // 77: scanoss.api.cryptography.v2.Cryptography.GetVersionsInRange:output_type -> scanoss.api.cryptography.v2.VersionsInRangeResponse
-	10, // 78: scanoss.api.cryptography.v2.Cryptography.GetComponentVersionsInRange:output_type -> scanoss.api.cryptography.v2.ComponentVersionsInRangeResponse
-	9,  // 79: scanoss.api.cryptography.v2.Cryptography.GetComponentsVersionsInRange:output_type -> scanoss.api.cryptography.v2.ComponentsVersionsInRangeResponse
-	14, // 80: scanoss.api.cryptography.v2.Cryptography.GetHintsInRange:output_type -> scanoss.api.cryptography.v2.HintsInRangeResponse
-	16, // 81: scanoss.api.cryptography.v2.Cryptography.GetComponentHintsInRange:output_type -> scanoss.api.cryptography.v2.ComponentHintsInRangeResponse
-	15, // 82: scanoss.api.cryptography.v2.Cryptography.GetComponentsHintsInRange:output_type -> scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse
-	13, // 83: scanoss.api.cryptography.v2.Cryptography.GetEncryptionHints:output_type -> scanoss.api.cryptography.v2.HintsResponse
-	18, // 84: scanoss.api.cryptography.v2.Cryptography.GetComponentEncryptionHints:output_type -> scanoss.api.cryptography.v2.ComponentEncryptionHintsResponse
-	17, // 85: scanoss.api.cryptography.v2.Cryptography.GetComponentsEncryptionHints:output_type -> scanoss.api.cryptography.v2.ComponentsEncryptionHintsResponse
-	38, // 86: scanoss.api.cryptography.v2.Cryptography.DownloadRuleset:output_type -> google.api.HttpBody
-	70, // [70:87] is the sub-list for method output_type
-	53, // [53:70] is the sub-list for method input_type
-	53, // [53:53] is the sub-list for extension type_name
-	53, // [53:53] is the sub-list for extension extendee
-	0,  // [0:53] is the sub-list for field type_name
+	2,  // 3: scanoss.api.cryptography.v2.ComponentsAlgorithmsResponse.components:type_name -> scanoss.api.cryptography.v2.ComponentAlgorithms
+	31, // 4: scanoss.api.cryptography.v2.ComponentsAlgorithmsResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	2,  // 5: scanoss.api.cryptography.v2.ComponentAlgorithmsResponse.component:type_name -> scanoss.api.cryptography.v2.ComponentAlgorithms
+	31, // 6: scanoss.api.cryptography.v2.ComponentAlgorithmsResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	21, // 7: scanoss.api.cryptography.v2.AlgorithmsInRangeResponse.purls:type_name -> scanoss.api.cryptography.v2.AlgorithmsInRangeResponse.Purl
+	31, // 8: scanoss.api.cryptography.v2.AlgorithmsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	22, // 9: scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse.components:type_name -> scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse.Component
+	31, // 10: scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	23, // 11: scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse.component:type_name -> scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse.Component
+	31, // 12: scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	24, // 13: scanoss.api.cryptography.v2.VersionsInRangeResponse.purls:type_name -> scanoss.api.cryptography.v2.VersionsInRangeResponse.Purl
+	31, // 14: scanoss.api.cryptography.v2.VersionsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	25, // 15: scanoss.api.cryptography.v2.ComponentsVersionsInRangeResponse.components:type_name -> scanoss.api.cryptography.v2.ComponentsVersionsInRangeResponse.Component
+	31, // 16: scanoss.api.cryptography.v2.ComponentsVersionsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	26, // 17: scanoss.api.cryptography.v2.ComponentVersionsInRangeResponse.component:type_name -> scanoss.api.cryptography.v2.ComponentVersionsInRangeResponse.Component
+	31, // 18: scanoss.api.cryptography.v2.ComponentVersionsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	11, // 19: scanoss.api.cryptography.v2.ComponentHints.hints:type_name -> scanoss.api.cryptography.v2.Hint
+	27, // 20: scanoss.api.cryptography.v2.HintsResponse.purls:type_name -> scanoss.api.cryptography.v2.HintsResponse.Purls
+	31, // 21: scanoss.api.cryptography.v2.HintsResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	28, // 22: scanoss.api.cryptography.v2.HintsInRangeResponse.purls:type_name -> scanoss.api.cryptography.v2.HintsInRangeResponse.Purl
+	31, // 23: scanoss.api.cryptography.v2.HintsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	29, // 24: scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.components:type_name -> scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.Component
+	31, // 25: scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	30, // 26: scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.component:type_name -> scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.Component
+	31, // 27: scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	12, // 28: scanoss.api.cryptography.v2.ComponentsEncryptionHintsResponse.components:type_name -> scanoss.api.cryptography.v2.ComponentHints
+	31, // 29: scanoss.api.cryptography.v2.ComponentsEncryptionHintsResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	12, // 30: scanoss.api.cryptography.v2.ComponentEncryptionHintsResponse.component:type_name -> scanoss.api.cryptography.v2.ComponentHints
+	31, // 31: scanoss.api.cryptography.v2.ComponentEncryptionHintsResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
+	0,  // 32: scanoss.api.cryptography.v2.AlgorithmResponse.Purls.algorithms:type_name -> scanoss.api.cryptography.v2.Algorithm
+	0,  // 33: scanoss.api.cryptography.v2.AlgorithmsInRangeResponse.Purl.algorithms:type_name -> scanoss.api.cryptography.v2.Algorithm
+	0,  // 34: scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse.Component.algorithms:type_name -> scanoss.api.cryptography.v2.Algorithm
+	0,  // 35: scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse.Component.algorithms:type_name -> scanoss.api.cryptography.v2.Algorithm
+	11, // 36: scanoss.api.cryptography.v2.HintsResponse.Purls.hints:type_name -> scanoss.api.cryptography.v2.Hint
+	11, // 37: scanoss.api.cryptography.v2.HintsInRangeResponse.Purl.hints:type_name -> scanoss.api.cryptography.v2.Hint
+	11, // 38: scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse.Component.hints:type_name -> scanoss.api.cryptography.v2.Hint
+	11, // 39: scanoss.api.cryptography.v2.ComponentHintsInRangeResponse.Component.hints:type_name -> scanoss.api.cryptography.v2.Hint
+	32, // 40: scanoss.api.cryptography.v2.Cryptography.Echo:input_type -> scanoss.api.common.v2.EchoRequest
+	33, // 41: scanoss.api.cryptography.v2.Cryptography.GetAlgorithms:input_type -> scanoss.api.common.v2.PurlRequest
+	34, // 42: scanoss.api.cryptography.v2.Cryptography.GetComponentAlgorithms:input_type -> scanoss.api.common.v2.ComponentRequest
+	35, // 43: scanoss.api.cryptography.v2.Cryptography.GetComponentsAlgorithms:input_type -> scanoss.api.common.v2.ComponentsRequest
+	33, // 44: scanoss.api.cryptography.v2.Cryptography.GetAlgorithmsInRange:input_type -> scanoss.api.common.v2.PurlRequest
+	34, // 45: scanoss.api.cryptography.v2.Cryptography.GetComponentAlgorithmsInRange:input_type -> scanoss.api.common.v2.ComponentRequest
+	35, // 46: scanoss.api.cryptography.v2.Cryptography.GetComponentsAlgorithmsInRange:input_type -> scanoss.api.common.v2.ComponentsRequest
+	33, // 47: scanoss.api.cryptography.v2.Cryptography.GetVersionsInRange:input_type -> scanoss.api.common.v2.PurlRequest
+	34, // 48: scanoss.api.cryptography.v2.Cryptography.GetComponentVersionsInRange:input_type -> scanoss.api.common.v2.ComponentRequest
+	35, // 49: scanoss.api.cryptography.v2.Cryptography.GetComponentsVersionsInRange:input_type -> scanoss.api.common.v2.ComponentsRequest
+	33, // 50: scanoss.api.cryptography.v2.Cryptography.GetHintsInRange:input_type -> scanoss.api.common.v2.PurlRequest
+	34, // 51: scanoss.api.cryptography.v2.Cryptography.GetComponentHintsInRange:input_type -> scanoss.api.common.v2.ComponentRequest
+	35, // 52: scanoss.api.cryptography.v2.Cryptography.GetComponentsHintsInRange:input_type -> scanoss.api.common.v2.ComponentsRequest
+	33, // 53: scanoss.api.cryptography.v2.Cryptography.GetEncryptionHints:input_type -> scanoss.api.common.v2.PurlRequest
+	34, // 54: scanoss.api.cryptography.v2.Cryptography.GetComponentEncryptionHints:input_type -> scanoss.api.common.v2.ComponentRequest
+	35, // 55: scanoss.api.cryptography.v2.Cryptography.GetComponentsEncryptionHints:input_type -> scanoss.api.common.v2.ComponentsRequest
+	19, // 56: scanoss.api.cryptography.v2.Cryptography.DownloadRuleset:input_type -> scanoss.api.cryptography.v2.RulesetDownloadRequest
+	36, // 57: scanoss.api.cryptography.v2.Cryptography.Echo:output_type -> scanoss.api.common.v2.EchoResponse
+	1,  // 58: scanoss.api.cryptography.v2.Cryptography.GetAlgorithms:output_type -> scanoss.api.cryptography.v2.AlgorithmResponse
+	4,  // 59: scanoss.api.cryptography.v2.Cryptography.GetComponentAlgorithms:output_type -> scanoss.api.cryptography.v2.ComponentAlgorithmsResponse
+	3,  // 60: scanoss.api.cryptography.v2.Cryptography.GetComponentsAlgorithms:output_type -> scanoss.api.cryptography.v2.ComponentsAlgorithmsResponse
+	5,  // 61: scanoss.api.cryptography.v2.Cryptography.GetAlgorithmsInRange:output_type -> scanoss.api.cryptography.v2.AlgorithmsInRangeResponse
+	7,  // 62: scanoss.api.cryptography.v2.Cryptography.GetComponentAlgorithmsInRange:output_type -> scanoss.api.cryptography.v2.ComponentAlgorithmsInRangeResponse
+	6,  // 63: scanoss.api.cryptography.v2.Cryptography.GetComponentsAlgorithmsInRange:output_type -> scanoss.api.cryptography.v2.ComponentsAlgorithmsInRangeResponse
+	8,  // 64: scanoss.api.cryptography.v2.Cryptography.GetVersionsInRange:output_type -> scanoss.api.cryptography.v2.VersionsInRangeResponse
+	10, // 65: scanoss.api.cryptography.v2.Cryptography.GetComponentVersionsInRange:output_type -> scanoss.api.cryptography.v2.ComponentVersionsInRangeResponse
+	9,  // 66: scanoss.api.cryptography.v2.Cryptography.GetComponentsVersionsInRange:output_type -> scanoss.api.cryptography.v2.ComponentsVersionsInRangeResponse
+	14, // 67: scanoss.api.cryptography.v2.Cryptography.GetHintsInRange:output_type -> scanoss.api.cryptography.v2.HintsInRangeResponse
+	16, // 68: scanoss.api.cryptography.v2.Cryptography.GetComponentHintsInRange:output_type -> scanoss.api.cryptography.v2.ComponentHintsInRangeResponse
+	15, // 69: scanoss.api.cryptography.v2.Cryptography.GetComponentsHintsInRange:output_type -> scanoss.api.cryptography.v2.ComponentsHintsInRangeResponse
+	13, // 70: scanoss.api.cryptography.v2.Cryptography.GetEncryptionHints:output_type -> scanoss.api.cryptography.v2.HintsResponse
+	18, // 71: scanoss.api.cryptography.v2.Cryptography.GetComponentEncryptionHints:output_type -> scanoss.api.cryptography.v2.ComponentEncryptionHintsResponse
+	17, // 72: scanoss.api.cryptography.v2.Cryptography.GetComponentsEncryptionHints:output_type -> scanoss.api.cryptography.v2.ComponentsEncryptionHintsResponse
+	37, // 73: scanoss.api.cryptography.v2.Cryptography.DownloadRuleset:output_type -> google.api.HttpBody
+	57, // [57:74] is the sub-list for method output_type
+	40, // [40:57] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_scanoss_api_cryptography_v2_scanoss_cryptography_proto_init() }

--- a/api/dependenciesv2/scanoss-dependencies.pb.go
+++ b/api/dependenciesv2/scanoss-dependencies.pb.go
@@ -473,10 +473,8 @@ type DependencyResponse_Dependencies struct {
 	Comment     string                         `protobuf:"bytes,6,opt,name=comment,proto3" json:"comment,omitempty"`
 	Requirement string                         `protobuf:"bytes,7,opt,name=requirement,proto3" json:"requirement,omitempty"`
 	// Status message describing the outcome of processing this component.
-	// Replaces the removed `error_message` field (position 8).
 	InfoMessage *string `protobuf:"bytes,10,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
 	// Status code identifying the outcome of processing this component.
-	// Replaces the removed `error_code` field (position 9).
 	//
 	// Possible values:
 	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.

--- a/api/licensesv2/scanoss-licenses.pb.go
+++ b/api/licensesv2/scanoss-licenses.pb.go
@@ -788,10 +788,8 @@ type ComponentLicenseInfo struct {
 	// Component URL
 	Url string `protobuf:"bytes,10,opt,name=url,proto3" json:"url,omitempty"`
 	// Status message describing the outcome of processing this component.
-	// Replaces the removed `error_message` field (position 8).
 	InfoMessage *string `protobuf:"bytes,12,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
 	// Status code identifying the outcome of processing this component.
-	// Replaces the removed `error_code` field (position 11).
 	//
 	// Possible values:
 	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.

--- a/api/vulnerabilitiesv2/scanoss-vulnerabilities.pb.go
+++ b/api/vulnerabilitiesv2/scanoss-vulnerabilities.pb.go
@@ -177,10 +177,8 @@ type ComponentCpesInfo struct {
 	// List of Common Platform Enumeration identifiers associated with this component
 	Cpes []string `protobuf:"bytes,4,rep,name=cpes,proto3" json:"cpes,omitempty"`
 	// Status message describing the outcome of processing this component.
-	// Replaces the removed `error_message` field (position 5).
 	InfoMessage *string `protobuf:"bytes,7,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
 	// Status code identifying the outcome of processing this component.
-	// Replaces the removed `error_code` field (position 6).
 	//
 	// Possible values:
 	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
@@ -713,10 +711,8 @@ type ComponentVulnerabilityInfo struct {
 	// List of known vulnerabilities affecting this component
 	Vulnerabilities []*Vulnerability `protobuf:"bytes,4,rep,name=vulnerabilities,proto3" json:"vulnerabilities,omitempty"`
 	// Status message describing the outcome of processing this component.
-	// Replaces the removed `error_message` field (position 5).
 	InfoMessage *string `protobuf:"bytes,7,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
 	// Status code identifying the outcome of processing this component.
-	// Replaces the removed `error_code` field (position 6).
 	//
 	// Possible values:
 	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.

--- a/protobuf/scanoss/api/cryptography/v2/README.md
+++ b/protobuf/scanoss/api/cryptography/v2/README.md
@@ -50,8 +50,8 @@ curl -X GET 'https://api.scanoss.com/v2/cryptography/algorithms/component?purl=p
     "version": "",
     "requirement": ">=1.0.0",
     "algorithms": [],
-    "error_message": "Component not found in database",
-    "error_code": "COMPONENT_NOT_FOUND"
+    "info_message": "Component not found in database",
+    "info_code": "COMPONENT_NOT_FOUND"
   },
   "status": {
     "status": "SUCCESS",
@@ -68,8 +68,8 @@ curl -X GET 'https://api.scanoss.com/v2/cryptography/algorithms/component?purl=p
     "version": "",
     "requirement": ">=1.0.0",
     "algorithms": [],
-    "error_message": "Invalid PURL format provided",
-    "error_code": "INVALID_PURL"
+    "info_message": "Invalid PURL format provided",
+    "info_code": "INVALID_PURL"
   },
   "status": {
     "status": "SUCCESS",
@@ -78,21 +78,24 @@ curl -X GET 'https://api.scanoss.com/v2/cryptography/algorithms/component?purl=p
 }
 ```
 
-### Error Handling
+### Info Codes
 
-Component responses include optional error fields when issues occur during processing:
+Component blocks report the processing outcome via `info_code` and `info_message`:
 
-- `error_message`: Human-readable description of the error
-- `error_code`: Machine-readable error code for programmatic handling
+- `info_code`: Machine-readable code identifying the outcome of processing the component.
+- `info_message`: Human-readable description of the outcome.
 
-#### Error Codes
+The `info_code` field reports the outcome of processing each component. Possible values:
 
-- `INVALID_PURL`: The provided PURL format is invalid
-- `COMPONENT_NOT_FOUND`: The component was not found in the database
-- `NO_INFO`: No cryptographic information available for the component
-- `INVALID_SEMVER`: The provided semantic version or requirement is invalid
+| Code | Meaning |
+|------|---------|
+| `INVALID_PURL` | The provided Package URL (PURL) is invalid or malformed. |
+| `COMPONENT_NOT_FOUND` | The requested component could not be found in the database. |
+| `NO_INFO` | No cryptography information is available for the requested component. |
+| `INVALID_SEMVER` | The provided semantic version (SemVer) is invalid or malformed. |
+| `VERSION_NOT_FOUND` | The specific component version could not be found. |
 
-**Note**: When a component-level error occurs, the overall response status remains "SUCCESS" since the request was processed. Individual component errors are indicated within the component block itself.
+**Note**: When a component-level processing issue occurs, the overall response status remains `SUCCESS` since the request was processed. The per-component outcome is carried inside the component block via `info_code`/`info_message`.
 
 ## GetComponentsAlgorithms
 
@@ -174,8 +177,8 @@ curl -X POST 'https://api.scanoss.com/v2/cryptography/algorithms/components' \
       "requirement": ">=1.0.0",
       "version": "",
       "algorithms": [],
-      "error_message": "Component not found in database",
-      "error_code": "COMPONENT_NOT_FOUND"
+      "info_message": "Component not found in database",
+      "info_code": "COMPONENT_NOT_FOUND"
     }
   ],
   "status": {
@@ -249,8 +252,8 @@ Each algorithm object contains:
     "purl": "pkg:github/example/simple-utility",
     "versions": [],
     "algorithms": [],
-    "error_message": "Component not found: 'pkg:github/example/simple-utility'",
-    "error_code": "COMPONENT_NOT_FOUND"
+    "info_message": "Component not found: 'pkg:github/example/simple-utility'",
+    "info_code": "COMPONENT_NOT_FOUND"
   },
   "status": {
     "status": "SUCCESS",
@@ -404,8 +407,8 @@ Hints are classified into the following categories:
     "purl": "pkg:github/example/simple-utility",
     "version": "1.0.0",
     "hints": [],
-    "error_message": "No info found for: pkg:github/example/simple-utility",
-    "error_code": "NO_INFO"
+    "info_message": "No info found for: pkg:github/example/simple-utility",
+    "info_code": "NO_INFO"
     
   },
   "status": {

--- a/protobuf/scanoss/api/cryptography/v2/scanoss-cryptography.proto
+++ b/protobuf/scanoss/api/cryptography/v2/scanoss-cryptography.proto
@@ -348,8 +348,25 @@ message AlgorithmResponse {
     // List of cryptographic algorithms detected in this component version
     repeated Algorithm algorithms = 3;
 
-    optional  string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    //   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+    //   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+    optional string info_code = 7 [json_name = "info_code"];
   }
   // Algorithm details for each requested component
   repeated Purls purls = 1;
@@ -373,8 +390,25 @@ message ComponentAlgorithms {
   // List of cryptographic algorithms detected in this component version
   repeated Algorithm algorithms = 4;
 
-  optional string error_message = 5 [json_name = "error_message"];
-  optional common.v2.ErrorCode error_code = 6  [json_name = "error_code"];
+  // Field 5 previously held `string error_message`; field 6 previously held
+  // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were replaced
+  // by `info_message`/`info_code` below. These numbers and JSON names must
+  // never be reused, to avoid wire-type or semantic collisions with legacy
+  // clients still encoding them.
+  reserved 5, 6;
+  reserved "error_message", "error_code";
+
+  // Status message describing the outcome of processing this component.
+  optional string info_message = 7 [json_name = "info_message"];
+  // Status code identifying the outcome of processing this component.
+  //
+  // Possible values:
+  //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+  //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+  //   - "NO_INFO":             No cryptography information is available for the requested component.
+  //   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+  //   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+  optional string info_code = 8 [json_name = "info_code"];
 }
 
 /*
@@ -386,7 +420,7 @@ message ComponentAlgorithms {
 message ComponentsAlgorithmsResponse{
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
     json_schema: {
-      example: "{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \">=5.0.0\", \"version\": \"5.0.0\", \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}, {\"algorithm\": \"RSA\", \"strength\": \"Strong\"}]}, {\"purl\": \"pkg:github/unknown/component\", \"requirement\": \">=1.0.0\", \"version\": \"\", \"algorithms\": [], \"error_message\": \"Component not found in database\", \"error_code\": \"COMPONENT_NOT_FOUND\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Batch request processed\"}}";
+      example: "{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \">=5.0.0\", \"version\": \"5.0.0\", \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}, {\"algorithm\": \"RSA\", \"strength\": \"Strong\"}]}, {\"purl\": \"pkg:github/unknown/component\", \"requirement\": \">=1.0.0\", \"version\": \"\", \"algorithms\": [], \"info_message\": \"Component not found in database\", \"info_code\": \"COMPONENT_NOT_FOUND\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Batch request processed\"}}";
     }
   };
   // Algorithm information for each component in the batch
@@ -406,7 +440,7 @@ message ComponentAlgorithmsResponse {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
     json_schema: {
       example: "{\"component\":{\"purl\": \"pkg:github/scanoss/engine\", \"requirement\": \">=5.0.0\", \"version\": \"5.0.0\", \"algorithms\": [{\"algorithm\": \"AES\", \"strength\": \"Strong\"}, {\"algorithm\": \"RSA\", \"strength\": \"Strong\"}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Algorithms Successfully retrieved\"}}";
-      description: "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"requirement\\\":\\\">=1.0.0\\\",\\\"version\\\":\\\"\\\",\\\"algorithms\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}";
+      description: "Success example. For error cases, the component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\">=1.0.0\",\"version\":\"\",\"algorithms\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}";
     }
   };
   // Algorithm information for the component
@@ -431,8 +465,23 @@ message AlgorithmsInRangeResponse {
     // Algorithms list detected in that range
     repeated Algorithm algorithms = 3;
 
-    optional string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    optional string info_code = 7 [json_name = "info_code"];
   }
   // Cryptography details
   repeated Purl purls = 1;
@@ -463,8 +512,23 @@ message ComponentsAlgorithmsInRangeResponse {
     // List of cryptographic algorithms detected across the version range
     repeated Algorithm algorithms = 3;
 
-    optional string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    optional string info_code = 7 [json_name = "info_code"];
   }
   // Algorithm details for each component in the batch
   repeated Component components = 1;
@@ -495,8 +559,23 @@ message ComponentAlgorithmsInRangeResponse {
     // List of cryptographic algorithms detected across the version range
     repeated Algorithm algorithms = 3;
 
-    optional string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    optional string info_code = 7 [json_name = "info_code"];
   }
   Component component = 1;
   // Response status indicating success or failure
@@ -518,8 +597,23 @@ message ComponentAlgorithmsInRangeResponse {
     // List of versions that do not contain cryptography
     repeated string versions_without = 3 [json_name = "versions_without"];
 
-    optional string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    optional string info_code = 7 [json_name = "info_code"];
   }
   // Cryptography details
   repeated Purl purls = 1;
@@ -550,8 +644,23 @@ message ComponentsVersionsInRangeResponse {
     // List of versions in the specified range that do not contain cryptographic algorithms
     repeated string versions_without = 3 [json_name = "versions_without"];
 
-    optional string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    optional string info_code = 7 [json_name = "info_code"];
   }
   // Version details for each component in the batch
   repeated Component components = 1;
@@ -582,8 +691,23 @@ message ComponentVersionsInRangeResponse {
     // List of versions in the specified range that do not contain cryptographic algorithms
     repeated string versions_without = 3 [json_name = "versions_without"];
 
-    optional string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    optional string info_code = 7 [json_name = "info_code"];
   }
 
   // Version details for each component in the batch
@@ -630,8 +754,25 @@ message ComponentHints {
   // List of cryptographic hints detected in this component version
   repeated Hint hints = 4;
 
-  optional string error_message = 5 [json_name = "error_message"];
-  optional common.v2.ErrorCode error_code = 6  [json_name = "error_code"];
+  // Field 5 previously held `string error_message`; field 6 previously held
+  // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were replaced
+  // by `info_message`/`info_code` below. These numbers and JSON names must
+  // never be reused, to avoid wire-type or semantic collisions with legacy
+  // clients still encoding them.
+  reserved 5, 6;
+  reserved "error_message", "error_code";
+
+  // Status message describing the outcome of processing this component.
+  optional string info_message = 7 [json_name = "info_message"];
+  // Status code identifying the outcome of processing this component.
+  //
+  // Possible values:
+  //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+  //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+  //   - "NO_INFO":             No cryptography information is available for the requested component.
+  //   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+  //   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+  optional string info_code = 8 [json_name = "info_code"];
 }
 
 /*
@@ -647,8 +788,25 @@ message HintsResponse {
     // Algorithms list detected for that version
     repeated Hint hints = 3;
 
-    optional string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    //   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+    //   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+    optional string info_code = 7 [json_name = "info_code"];
   }
   // Purl encryption Hint
   repeated Purls purls = 1;
@@ -669,8 +827,23 @@ message HintsInRangeResponse {
     // Encryption hints
     repeated Hint hints = 3;
 
-    optional string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    optional string info_code = 7 [json_name = "info_code"];
   }
   // Purl encryption hints
   repeated Purl purls = 1;
@@ -684,7 +857,7 @@ message HintsInRangeResponse {
 message ComponentsHintsInRangeResponse {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
     json_schema: {
-      example: "{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"5.0.0\", \"5.1.0\"], \"hints\": [{\"id\": \"openssl-hint-001\", \"name\": \"OpenSSL\", \"description\": \"Industry standard cryptographic library\", \"category\": \"library\", \"url\": \"https://www.openssl.org/\", \"purl\": \"pkg:generic/openssl@3.0.0\"}]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\", \"versions\": [], \"hints\": [], \"error_message\": \"Component not found in database\", \"error_code\": \"COMPONENT_NOT_FOUND\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Cryptographic hints in range retrieved\"}}";
+      example: "{\"components\":[{\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"5.0.0\", \"5.1.0\"], \"hints\": [{\"id\": \"openssl-hint-001\", \"name\": \"OpenSSL\", \"description\": \"Industry standard cryptographic library\", \"category\": \"library\", \"url\": \"https://www.openssl.org/\", \"purl\": \"pkg:generic/openssl@3.0.0\"}]}, {\"purl\": \"pkg:github/scanoss/scanoss.py\", \"versions\": [], \"hints\": [], \"info_message\": \"Component not found in database\", \"info_code\": \"COMPONENT_NOT_FOUND\"}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Cryptographic hints in range retrieved\"}}";
     }
   };
   // Information about the requested purl
@@ -696,8 +869,23 @@ message ComponentsHintsInRangeResponse {
     // Encryption hints
     repeated Hint hints = 3;
 
-    optional string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    optional string info_code = 7 [json_name = "info_code"];
   }
   // Purl encryption hints
   repeated Component components = 1;
@@ -712,7 +900,7 @@ message ComponentHintsInRangeResponse {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_schema) = {
     json_schema: {
       example: "{\"component\": {\"purl\": \"pkg:github/scanoss/engine\", \"versions\": [\"5.0.0\", \"5.1.0\", \"5.2.0\"], \"hints\": [{\"id\": \"openssl-hint-001\", \"name\": \"OpenSSL\", \"description\": \"Industry standard cryptographic library\", \"category\": \"library\", \"url\": \"https://www.openssl.org/\", \"purl\": \"pkg:generic/openssl@3.0.0\"}]}, \"status\": {\"status\": \"SUCCESS\", \"message\": \"Cryptographic hints in range retrieved\"}}";
-      description: "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"versions\\\":[],\\\"hints\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}";
+      description: "Success example. For error cases, the component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"versions\":[],\"hints\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}";
     }
   };
   // Information about the requested purl
@@ -724,8 +912,23 @@ message ComponentHintsInRangeResponse {
     // Encryption hints
     repeated Hint hints = 3;
 
-    optional string error_message = 4 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 5  [json_name = "error_code"];
+    // Field 4 previously held `string error_message`; field 5 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were
+    // replaced by `info_message`/`info_code` below. These numbers and JSON
+    // names must never be reused, to avoid wire-type or semantic collisions
+    // with legacy clients still encoding them.
+    reserved 4, 5;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 6 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No cryptography information is available for the requested component.
+    optional string info_code = 7 [json_name = "info_code"];
   }
   // Purl encryption hints
   Component component = 1;

--- a/protobuf/scanoss/api/cryptography/v2/scanoss-cryptography.swagger.json
+++ b/protobuf/scanoss/api/cryptography/v2/scanoss-cryptography.swagger.json
@@ -690,11 +690,13 @@
           },
           "title": "List of cryptographic algorithms detected in this component version"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "description": "Algorithm information for a specific component."
@@ -739,11 +741,13 @@
           },
           "title": "Algorithms list detected in that range"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component."
         }
       },
       "title": "Information for a given PURL"
@@ -771,11 +775,13 @@
           },
           "title": "List of cryptographic algorithms detected in this component version"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "description": "Cryptographic algorithm information for a specific component identified by PURL and version.\n\nContains comprehensive algorithm details including detected algorithms and their\nstrength classifications for software components."
@@ -839,11 +845,13 @@
           },
           "title": "List of cryptographic algorithms detected across the version range"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component."
         }
       },
       "description": "Algorithm information for a specific component across version ranges."
@@ -881,7 +889,7 @@
           "title": "Response status indicating success or failure"
         }
       },
-      "description": "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"requirement\\\":\\\"\u003e=1.0.0\\\",\\\"version\\\":\\\"\\\",\\\"algorithms\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}"
+      "description": "Success example. For error cases, the component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"requirement\":\"\u003e=1.0.0\",\"version\":\"\",\"algorithms\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}"
     },
     "v2ComponentEncryptionHintsResponse": {
       "type": "object",
@@ -941,11 +949,13 @@
           },
           "title": "List of cryptographic hints detected in this component version"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "description": "Cryptographic hint information for a specific component identified by PURL and version.\n\nContains comprehensive cryptographic hints about protocols, libraries, SDKs and frameworks\nused by the component, providing insights into cryptographic dependencies and usage patterns."
@@ -986,7 +996,7 @@
           "title": "Response status"
         }
       },
-      "description": "Success example. For error cases, component block includes error_message and error_code fields, e.g.: {\\\"component\\\":{\\\"purl\\\":\\\"pkg:github/unknown/component\\\",\\\"versions\\\":[],\\\"hints\\\":[],\\\"error_message\\\":\\\"Component not found in database\\\",\\\"error_code\\\":\\\"COMPONENT_NOT_FOUND\\\"},\\\"status\\\":{\\\"status\\\":\\\"SUCCESS\\\",\\\"message\\\":\\\"Request processed\\\"}}",
+      "description": "Success example. For error cases, the component block reports the processing status via info_message and info_code. Example: {\"component\":{\"purl\":\"pkg:github/unknown/component\",\"versions\":[],\"hints\":[],\"info_message\":\"Component not found in database\",\"info_code\":\"COMPONENT_NOT_FOUND\"},\"status\":{\"status\":\"SUCCESS\",\"message\":\"Request processed\"}}",
       "title": "*\nHints of Encryption protocols, libraries, SDKs and frameworks for a purls in range"
     },
     "v2ComponentHintsInRangeResponseComponent": {
@@ -1011,11 +1021,13 @@
           },
           "title": "Encryption hints"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component."
         }
       },
       "title": "Information about the requested purl"
@@ -1093,11 +1105,13 @@
           },
           "title": "List of versions in the specified range that do not contain cryptographic algorithms"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component."
         }
       },
       "description": "Version information for a specific component categorized by cryptographic presence."
@@ -1175,11 +1189,13 @@
           },
           "title": "List of cryptographic algorithms detected across the version range"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component."
         }
       },
       "description": "Algorithm information for a specific component across version ranges."
@@ -1208,8 +1224,8 @@
             "requirement": "\u003e=1.0.0",
             "version": "",
             "algorithms": [],
-            "error_message": "Component not found in database",
-            "error_code": "COMPONENT_NOT_FOUND"
+            "info_message": "Component not found in database",
+            "info_code": "COMPONENT_NOT_FOUND"
           }
         ],
         "status": {
@@ -1314,8 +1330,8 @@
             "purl": "pkg:github/scanoss/scanoss.py",
             "versions": [],
             "hints": [],
-            "error_message": "Component not found in database",
-            "error_code": "COMPONENT_NOT_FOUND"
+            "info_message": "Component not found in database",
+            "info_code": "COMPONENT_NOT_FOUND"
           }
         ],
         "status": {
@@ -1361,11 +1377,13 @@
           },
           "title": "Encryption hints"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component."
         }
       },
       "title": "Information about the requested purl"
@@ -1463,11 +1481,13 @@
           },
           "title": "List of versions in the specified range that do not contain cryptographic algorithms"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component."
         }
       },
       "description": "Version information for a specific component categorized by cryptographic presence."
@@ -1489,19 +1509,6 @@
         }
       },
       "description": "Echo Message Response."
-    },
-    "v2ErrorCode": {
-      "type": "string",
-      "enum": [
-        "INVALID_PURL",
-        "COMPONENT_NOT_FOUND",
-        "NO_INFO",
-        "INVALID_SEMVER",
-        "VERSION_NOT_FOUND",
-        "TOO_MANY_CONTRIBUTORS"
-      ],
-      "default": "INVALID_PURL",
-      "description": "Error code enum for component analysis operations.\nRepresents the various error conditions that can occur during component processing and validation.\n\n - INVALID_PURL: The provided Package URL (PURL) is invalid or malformed\n - COMPONENT_NOT_FOUND: The requested component could not be found in the database\n - NO_INFO: No information is available for the requested component\n - INVALID_SEMVER: The provided semantic version (SemVer) is invalid or malformed\n - VERSION_NOT_FOUND: Component version not found\n - TOO_MANY_CONTRIBUTORS: Too many contributors for a component. Used by Geoprovenance service"
     },
     "v2Hint": {
       "type": "object",
@@ -1573,11 +1580,13 @@
           },
           "title": "Encryption hints"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component."
         }
       },
       "title": "Information about the requested purl"
@@ -1619,11 +1628,13 @@
           },
           "title": "Algorithms list detected for that version"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "title": "Information for a given purl"
@@ -1714,11 +1725,13 @@
           },
           "title": "List of versions that do not contain cryptography"
         },
-        "error_message": {
-          "type": "string"
+        "info_message": {
+          "type": "string",
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No cryptography information is available for the requested component."
         }
       },
       "title": "Information for a given PURL"

--- a/protobuf/scanoss/api/dependencies/v2/README.md
+++ b/protobuf/scanoss/api/dependencies/v2/README.md
@@ -2,8 +2,6 @@
 
 Provides comprehensive dependency analysis for software components including direct and transitive dependency resolution across multiple ecosystems.
 
-> **Breaking change:** The `error_message` and `error_code` fields on `DependencyResponse.Dependencies` have been removed. Component-level processing outcomes are now reported via the `info_message` and `info_code` fields. Clients must migrate to read `info_message`/`info_code`; responses no longer include `error_message`/`error_code`.
-
 ## GetTransitiveDependencies
 
 Analyzes software components to retrieve their complete transitive dependency tree, helping identify all indirect dependencies that would be pulled into a project.

--- a/protobuf/scanoss/api/dependencies/v2/scanoss-dependencies.proto
+++ b/protobuf/scanoss/api/dependencies/v2/scanoss-dependencies.proto
@@ -159,10 +159,8 @@ message DependencyResponse {
     reserved "error_message", "error_code";
 
     // Status message describing the outcome of processing this component.
-    // Replaces the removed `error_message` field (position 8).
     optional string info_message = 10 [json_name = "info_message"];
     // Status code identifying the outcome of processing this component.
-    // Replaces the removed `error_code` field (position 9).
     //
     // Possible values:
     //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.

--- a/protobuf/scanoss/api/dependencies/v2/scanoss-dependencies.swagger.json
+++ b/protobuf/scanoss/api/dependencies/v2/scanoss-dependencies.swagger.json
@@ -177,11 +177,11 @@
         },
         "info_message": {
           "type": "string",
-          "description": "Status message describing the outcome of processing this component.\nReplaces the removed `error_message` field (position 8)."
+          "description": "Status message describing the outcome of processing this component."
         },
         "info_code": {
           "type": "string",
-          "description": "Status code identifying the outcome of processing this component.\nReplaces the removed `error_code` field (position 9).\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No dependency information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No dependency information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       }
     },

--- a/protobuf/scanoss/api/licenses/v2/README.md
+++ b/protobuf/scanoss/api/licenses/v2/README.md
@@ -2,8 +2,6 @@
 
 Analyzes software components to identify licensing information.
 
-> **Breaking change:** The `error_message` and `error_code` fields on `ComponentLicenseInfo` have been removed. Component-level processing outcomes are now reported via the `info_message` and `info_code` fields. Clients must migrate to read `info_message`/`info_code`; responses no longer include `error_message`/`error_code`.
-
 ## GetComponentLicenses
 Retrieves license information for a single software component identified by Package URL. 
 Examines source code, license files, and package metadata to determine which licenses apply to the component. 

--- a/protobuf/scanoss/api/licenses/v2/scanoss-licenses.proto
+++ b/protobuf/scanoss/api/licenses/v2/scanoss-licenses.proto
@@ -392,10 +392,8 @@ message ComponentLicenseInfo {
   reserved "error_message", "error_code";
 
   // Status message describing the outcome of processing this component.
-  // Replaces the removed `error_message` field (position 8).
   optional string info_message = 12 [json_name = "info_message"];
   // Status code identifying the outcome of processing this component.
-  // Replaces the removed `error_code` field (position 11).
   //
   // Possible values:
   //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.

--- a/protobuf/scanoss/api/licenses/v2/scanoss-licenses.swagger.json
+++ b/protobuf/scanoss/api/licenses/v2/scanoss-licenses.swagger.json
@@ -371,11 +371,11 @@
         },
         "info_message": {
           "type": "string",
-          "description": "Status message describing the outcome of processing this component.\nReplaces the removed `error_message` field (position 8)."
+          "description": "Status message describing the outcome of processing this component."
         },
         "info_code": {
           "type": "string",
-          "description": "Status code identifying the outcome of processing this component.\nReplaces the removed `error_code` field (position 11).\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No license information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No license information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "description": "License information for a specific component identified by PURL and version."

--- a/protobuf/scanoss/api/vulnerabilities/v2/README.md
+++ b/protobuf/scanoss/api/vulnerabilities/v2/README.md
@@ -2,8 +2,6 @@
 
 Provides vulnerability intelligence for software components including CPE enumeration and vulnerability analysis.
 
-> **Breaking change:** The `error_message` and `error_code` fields on `ComponentVulnerabilityInfo` and `ComponentCpesInfo` have been removed. Component-level processing outcomes are now reported via the `info_message` and `info_code` fields. Clients must migrate to read `info_message`/`info_code`; responses no longer include `error_message`/`error_code`.
-
 ## GetComponentCpes
 
 Retrieves Common Platform Enumeration (CPE) identifiers for a single software component identified by Package URL. 

--- a/protobuf/scanoss/api/vulnerabilities/v2/scanoss-vulnerabilities.proto
+++ b/protobuf/scanoss/api/vulnerabilities/v2/scanoss-vulnerabilities.proto
@@ -228,10 +228,8 @@ message ComponentCpesInfo {
   reserved "error_message", "error_code";
 
   // Status message describing the outcome of processing this component.
-  // Replaces the removed `error_message` field (position 5).
   optional string info_message = 7 [json_name = "info_message"];
   // Status code identifying the outcome of processing this component.
-  // Replaces the removed `error_code` field (position 6).
   //
   // Possible values:
   //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
@@ -389,10 +387,8 @@ message ComponentVulnerabilityInfo {
   reserved "error_message", "error_code";
 
   // Status message describing the outcome of processing this component.
-  // Replaces the removed `error_message` field (position 5).
   optional string info_message = 7 [json_name = "info_message"];
   // Status code identifying the outcome of processing this component.
-  // Replaces the removed `error_code` field (position 6).
   //
   // Possible values:
   //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.

--- a/protobuf/scanoss/api/vulnerabilities/v2/scanoss-vulnerabilities.swagger.json
+++ b/protobuf/scanoss/api/vulnerabilities/v2/scanoss-vulnerabilities.swagger.json
@@ -343,11 +343,11 @@
         },
         "info_message": {
           "type": "string",
-          "description": "Status message describing the outcome of processing this component.\nReplaces the removed `error_message` field (position 5)."
+          "description": "Status message describing the outcome of processing this component."
         },
         "info_code": {
           "type": "string",
-          "description": "Status code identifying the outcome of processing this component.\nReplaces the removed `error_code` field (position 6).\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No CPE information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No CPE information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "description": "Common Platform Enumeration information for a specific component.\n\nContains CPE identifiers that can be used to match the component\nagainst vulnerability databases and security advisories."
@@ -425,11 +425,11 @@
         },
         "info_message": {
           "type": "string",
-          "description": "Status message describing the outcome of processing this component.\nReplaces the removed `error_message` field (position 5)."
+          "description": "Status message describing the outcome of processing this component."
         },
         "info_code": {
           "type": "string",
-          "description": "Status code identifying the outcome of processing this component.\nReplaces the removed `error_code` field (position 6).\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No vulnerability information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No vulnerability information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "description": "Vulnerability information for a specific component identified by PURL and version.\n\nContains comprehensive vulnerability details including CVE information, severity scores,\nand security metadata for software components."


### PR DESCRIPTION
…o_massage/info_code in cryptography responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Cryptography API v2 now uses info_message/info_code instead of error_message/error_code for per-component outcomes; update integrations to read the new fields.

* **Documentation**
  * "Error Handling" renamed to "Info Codes"; examples and descriptions updated to show info_code/info_message and an expanded code set (adds VERSION_NOT_FOUND). Overall response status may remain SUCCESS while component details appear in info_code/info_message.

* **Release**
  * Added 0.41.0 entry with comparison link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->