### PR TITLE
chore(components):SP-4329 replace error_message/error_code witn info_…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.42.0] - 2026-04-20
+### Added
+- Added `info_message` and `info_code` fields to `ComponentStatusResponse.VersionStatus` and `ComponentStatusResponse.ComponentStatus` messages in Components responses as the definitive fields for reporting the outcome of processing each component
+### Removed
+- **Breaking change:** Removed `error_message` and `error_code` fields from `ComponentStatusResponse.VersionStatus` and `ComponentStatusResponse.ComponentStatus` messages in Components responses. Clients must migrate to `info_message`/`info_code`
+
 ## [0.41.0] - 2026-04-20
 ### Added
 - Added `info_message` and `info_code` fields to all Cryptography response messages (`AlgorithmResponse.Purls`, `ComponentAlgorithms`, `AlgorithmsInRangeResponse.Purl`, `ComponentsAlgorithmsInRangeResponse.Component`, `ComponentAlgorithmsInRangeResponse.Component`, `VersionsInRangeResponse.Purl`, `ComponentsVersionsInRangeResponse.Component`, `ComponentVersionsInRangeResponse.Component`, `ComponentHints`, `HintsResponse.Purls`, `HintsInRangeResponse.Purl`, `ComponentsHintsInRangeResponse.Component`, `ComponentHintsInRangeResponse.Component`)
@@ -307,6 +314,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Vulnerabilities
 - Added REST endpoint support for each service also
 
+[0.42.0]: https://github.com/scanoss/papi/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/scanoss/papi/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/scanoss/papi/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/scanoss/papi/compare/v0.38.0...v0.39.0

--- a/api/componentsv2/scanoss-components.pb.go
+++ b/api/componentsv2/scanoss-components.pb.go
@@ -692,9 +692,15 @@ type ComponentStatusResponse_VersionStatus struct {
 	IndexedDate string `protobuf:"bytes,4,opt,name=indexed_date,proto3" json:"indexed_date,omitempty"`
 	// Date that the status was checked
 	StatusChangeDate string `protobuf:"bytes,5,opt,name=status_change_date,proto3" json:"status_change_date,omitempty"`
-	// States if something went wrong while searching for the version of this component version in the DB
-	ErrorMessage  *string             `protobuf:"bytes,6,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,7,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,8,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "NO_INFO":             No status information is available for the requested component.
+	//   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+	//   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+	InfoCode      *string `protobuf:"bytes,9,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -764,18 +770,18 @@ func (x *ComponentStatusResponse_VersionStatus) GetStatusChangeDate() string {
 	return ""
 }
 
-func (x *ComponentStatusResponse_VersionStatus) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentStatusResponse_VersionStatus) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentStatusResponse_VersionStatus) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentStatusResponse_VersionStatus) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Component status details (ignoring version)
@@ -791,9 +797,15 @@ type ComponentStatusResponse_ComponentStatus struct {
 	LastIndexedDate string `protobuf:"bytes,4,opt,name=last_indexed_date,proto3" json:"last_indexed_date,omitempty"`
 	// Date of the last detected change
 	StatusChangeDate string `protobuf:"bytes,5,opt,name=status_change_date,proto3" json:"status_change_date,omitempty"`
-	// States if something went wrong while searching for the version of this component in the DB
-	ErrorMessage  *string             `protobuf:"bytes,6,opt,name=error_message,proto3,oneof" json:"error_message,omitempty"`
-	ErrorCode     *commonv2.ErrorCode `protobuf:"varint,7,opt,name=error_code,proto3,enum=scanoss.api.common.v2.ErrorCode,oneof" json:"error_code,omitempty"`
+	// Status message describing the outcome of processing this component.
+	InfoMessage *string `protobuf:"bytes,8,opt,name=info_message,proto3,oneof" json:"info_message,omitempty"`
+	// Status code identifying the outcome of processing this component.
+	//
+	// Possible values:
+	//   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+	//   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+	//   - "NO_INFO":             No status information is available for the requested component.
+	InfoCode      *string `protobuf:"bytes,9,opt,name=info_code,proto3,oneof" json:"info_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -863,18 +875,18 @@ func (x *ComponentStatusResponse_ComponentStatus) GetStatusChangeDate() string {
 	return ""
 }
 
-func (x *ComponentStatusResponse_ComponentStatus) GetErrorMessage() string {
-	if x != nil && x.ErrorMessage != nil {
-		return *x.ErrorMessage
+func (x *ComponentStatusResponse_ComponentStatus) GetInfoMessage() string {
+	if x != nil && x.InfoMessage != nil {
+		return *x.InfoMessage
 	}
 	return ""
 }
 
-func (x *ComponentStatusResponse_ComponentStatus) GetErrorCode() commonv2.ErrorCode {
-	if x != nil && x.ErrorCode != nil {
-		return *x.ErrorCode
+func (x *ComponentStatusResponse_ComponentStatus) GetInfoCode() string {
+	if x != nil && x.InfoCode != nil {
+		return *x.InfoCode
 	}
-	return commonv2.ErrorCode(0)
+	return ""
 }
 
 // Component details
@@ -1188,38 +1200,38 @@ const file_scanoss_api_components_v2_scanoss_components_proto_rawDesc = "" +
 	"\n" +
 	"statistics\x18\x03 \x01(\v2(.scanoss.api.components.v2.CompStatisticR\n" +
 	"statistics:\xea\x02\x92A\xe6\x02\n" +
-	"\xe3\x02J\xe0\x02{\"component_statistics\": [{\"purl\": \"pkg:github/scanoss/engine@5.0.0\", \"version\": \"5.0.0\", \"statistics\": {\"total_source_files\": 156, \"total_lines\": 25430, \"total_blank_lines\": 3420, \"languages\": [{\"name\": \"C\", \"files\": 89}, {\"name\": \"C Header\", \"files\": 45}]}}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Component statistics successfully retrieved\"}}\"\xeb\n" +
+	"\xe3\x02J\xe0\x02{\"component_statistics\": [{\"purl\": \"pkg:github/scanoss/engine@5.0.0\", \"version\": \"5.0.0\", \"statistics\": {\"total_source_files\": 156, \"total_lines\": 25430, \"total_blank_lines\": 3420, \"languages\": [{\"name\": \"C\", \"files\": 89}, {\"name\": \"C Header\", \"files\": 45}]}}], \"status\": {\"status\": \"SUCCESS\", \"message\": \"Component statistics successfully retrieved\"}}\"\xe9\n" +
 	"\n" +
 	"\x17ComponentStatusResponse\x12\x12\n" +
 	"\x04purl\x18\x01 \x01(\tR\x04purl\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
 	"\vrequirement\x18\x03 \x01(\tR\vrequirement\x12h\n" +
 	"\x0eversion_status\x18\x04 \x01(\v2@.scanoss.api.components.v2.ComponentStatusResponse.VersionStatusR\x0eversion_status\x12n\n" +
-	"\x10component_status\x18\x05 \x01(\v2B.scanoss.api.components.v2.ComponentStatusResponse.ComponentStatusR\x10component_status\x1a\xd6\x02\n" +
+	"\x10component_status\x18\x05 \x01(\v2B.scanoss.api.components.v2.ComponentStatusResponse.ComponentStatusR\x10component_status\x1a\xd5\x02\n" +
 	"\rVersionStatus\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12,\n" +
 	"\x11repository_status\x18\x03 \x01(\tR\x11repository_status\x12\"\n" +
 	"\findexed_date\x18\x04 \x01(\tR\findexed_date\x12.\n" +
-	"\x12status_change_date\x18\x05 \x01(\tR\x12status_change_date\x12)\n" +
-	"\rerror_message\x18\x06 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x12status_change_date\x18\x05 \x01(\tR\x12status_change_date\x12'\n" +
+	"\finfo_message\x18\b \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\t \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\a \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code\x1a\xf8\x02\n" +
+	"_info_codeJ\x04\b\x06\x10\aJ\x04\b\a\x10\bR\rerror_messageR\n" +
+	"error_code\x1a\xf7\x02\n" +
 	"\x0fComponentStatus\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12,\n" +
 	"\x11repository_status\x18\x02 \x01(\tR\x11repository_status\x12.\n" +
 	"\x12first_indexed_date\x18\x03 \x01(\tR\x12first_indexed_date\x12,\n" +
 	"\x11last_indexed_date\x18\x04 \x01(\tR\x11last_indexed_date\x12.\n" +
-	"\x12status_change_date\x18\x05 \x01(\tR\x12status_change_date\x12)\n" +
-	"\rerror_message\x18\x06 \x01(\tH\x00R\rerror_message\x88\x01\x01\x12E\n" +
+	"\x12status_change_date\x18\x05 \x01(\tR\x12status_change_date\x12'\n" +
+	"\finfo_message\x18\b \x01(\tH\x00R\finfo_message\x88\x01\x01\x12!\n" +
+	"\tinfo_code\x18\t \x01(\tH\x01R\tinfo_code\x88\x01\x01B\x0f\n" +
+	"\r_info_messageB\f\n" +
 	"\n" +
-	"error_code\x18\a \x01(\x0e2 .scanoss.api.common.v2.ErrorCodeH\x01R\n" +
-	"error_code\x88\x01\x01B\x10\n" +
-	"\x0e_error_messageB\r\n" +
-	"\v_error_code:\xd7\x02\x92A\xd3\x02\n" +
+	"_info_codeJ\x04\b\x06\x10\aJ\x04\b\a\x10\bR\rerror_messageR\n" +
+	"error_code:\xd7\x02\x92A\xd3\x02\n" +
 	"\xd0\x02J\xcd\x02{\"purl\": \"pkg:npm/strive-molu-axios\",\"name\": \"strive-molu-axios\", \"requirement\": \"^0.0.1\", \"version_status\": {\"version\": \"0.0.1-beta.1\", \"status\": \"deleted\", \"indexed_date\": \"2024-06-21\", \"check_date\": \"2026-02-01\" }, \"component_status\": { \"status\": \"active\", \"first_indexed_date\": \"2022-03-01\", \"last_indexed_date\": \"2026-02-15\" } }\"\x9b\x04\n" +
 	"\x18ComponentsStatusResponse\x12R\n" +
 	"\n" +
@@ -1308,11 +1320,10 @@ var file_scanoss_api_components_v2_scanoss_components_proto_goTypes = []any{
 	(*CompVersionResponse_Version)(nil),                     // 14: scanoss.api.components.v2.CompVersionResponse.Version
 	(*CompVersionResponse_Component)(nil),                   // 15: scanoss.api.components.v2.CompVersionResponse.Component
 	(*commonv2.StatusResponse)(nil),                         // 16: scanoss.api.common.v2.StatusResponse
-	(commonv2.ErrorCode)(0),                                 // 17: scanoss.api.common.v2.ErrorCode
-	(*commonv2.EchoRequest)(nil),                            // 18: scanoss.api.common.v2.EchoRequest
-	(*commonv2.ComponentsRequest)(nil),                      // 19: scanoss.api.common.v2.ComponentsRequest
-	(*commonv2.ComponentRequest)(nil),                       // 20: scanoss.api.common.v2.ComponentRequest
-	(*commonv2.EchoResponse)(nil),                           // 21: scanoss.api.common.v2.EchoResponse
+	(*commonv2.EchoRequest)(nil),                            // 17: scanoss.api.common.v2.EchoRequest
+	(*commonv2.ComponentsRequest)(nil),                      // 18: scanoss.api.common.v2.ComponentsRequest
+	(*commonv2.ComponentRequest)(nil),                       // 19: scanoss.api.common.v2.ComponentRequest
+	(*commonv2.EchoResponse)(nil),                           // 20: scanoss.api.common.v2.EchoResponse
 }
 var file_scanoss_api_components_v2_scanoss_components_proto_depIdxs = []int32{
 	8,  // 0: scanoss.api.components.v2.CompStatistic.languages:type_name -> scanoss.api.components.v2.CompStatistic.Language
@@ -1327,27 +1338,25 @@ var file_scanoss_api_components_v2_scanoss_components_proto_depIdxs = []int32{
 	15, // 9: scanoss.api.components.v2.CompVersionResponse.component:type_name -> scanoss.api.components.v2.CompVersionResponse.Component
 	16, // 10: scanoss.api.components.v2.CompVersionResponse.status:type_name -> scanoss.api.common.v2.StatusResponse
 	1,  // 11: scanoss.api.components.v2.ComponentsStatisticResponse.ComponentStatistics.statistics:type_name -> scanoss.api.components.v2.CompStatistic
-	17, // 12: scanoss.api.components.v2.ComponentStatusResponse.VersionStatus.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	17, // 13: scanoss.api.components.v2.ComponentStatusResponse.ComponentStatus.error_code:type_name -> scanoss.api.common.v2.ErrorCode
-	13, // 14: scanoss.api.components.v2.CompVersionResponse.Version.licenses:type_name -> scanoss.api.components.v2.CompVersionResponse.License
-	14, // 15: scanoss.api.components.v2.CompVersionResponse.Component.versions:type_name -> scanoss.api.components.v2.CompVersionResponse.Version
-	18, // 16: scanoss.api.components.v2.Components.Echo:input_type -> scanoss.api.common.v2.EchoRequest
-	0,  // 17: scanoss.api.components.v2.Components.SearchComponents:input_type -> scanoss.api.components.v2.CompSearchRequest
-	6,  // 18: scanoss.api.components.v2.Components.GetComponentVersions:input_type -> scanoss.api.components.v2.CompVersionRequest
-	19, // 19: scanoss.api.components.v2.Components.GetComponentStatistics:input_type -> scanoss.api.common.v2.ComponentsRequest
-	20, // 20: scanoss.api.components.v2.Components.GetComponentStatus:input_type -> scanoss.api.common.v2.ComponentRequest
-	19, // 21: scanoss.api.components.v2.Components.GetComponentsStatus:input_type -> scanoss.api.common.v2.ComponentsRequest
-	21, // 22: scanoss.api.components.v2.Components.Echo:output_type -> scanoss.api.common.v2.EchoResponse
-	5,  // 23: scanoss.api.components.v2.Components.SearchComponents:output_type -> scanoss.api.components.v2.CompSearchResponse
-	7,  // 24: scanoss.api.components.v2.Components.GetComponentVersions:output_type -> scanoss.api.components.v2.CompVersionResponse
-	2,  // 25: scanoss.api.components.v2.Components.GetComponentStatistics:output_type -> scanoss.api.components.v2.ComponentsStatisticResponse
-	3,  // 26: scanoss.api.components.v2.Components.GetComponentStatus:output_type -> scanoss.api.components.v2.ComponentStatusResponse
-	4,  // 27: scanoss.api.components.v2.Components.GetComponentsStatus:output_type -> scanoss.api.components.v2.ComponentsStatusResponse
-	22, // [22:28] is the sub-list for method output_type
-	16, // [16:22] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	13, // 12: scanoss.api.components.v2.CompVersionResponse.Version.licenses:type_name -> scanoss.api.components.v2.CompVersionResponse.License
+	14, // 13: scanoss.api.components.v2.CompVersionResponse.Component.versions:type_name -> scanoss.api.components.v2.CompVersionResponse.Version
+	17, // 14: scanoss.api.components.v2.Components.Echo:input_type -> scanoss.api.common.v2.EchoRequest
+	0,  // 15: scanoss.api.components.v2.Components.SearchComponents:input_type -> scanoss.api.components.v2.CompSearchRequest
+	6,  // 16: scanoss.api.components.v2.Components.GetComponentVersions:input_type -> scanoss.api.components.v2.CompVersionRequest
+	18, // 17: scanoss.api.components.v2.Components.GetComponentStatistics:input_type -> scanoss.api.common.v2.ComponentsRequest
+	19, // 18: scanoss.api.components.v2.Components.GetComponentStatus:input_type -> scanoss.api.common.v2.ComponentRequest
+	18, // 19: scanoss.api.components.v2.Components.GetComponentsStatus:input_type -> scanoss.api.common.v2.ComponentsRequest
+	20, // 20: scanoss.api.components.v2.Components.Echo:output_type -> scanoss.api.common.v2.EchoResponse
+	5,  // 21: scanoss.api.components.v2.Components.SearchComponents:output_type -> scanoss.api.components.v2.CompSearchResponse
+	7,  // 22: scanoss.api.components.v2.Components.GetComponentVersions:output_type -> scanoss.api.components.v2.CompVersionResponse
+	2,  // 23: scanoss.api.components.v2.Components.GetComponentStatistics:output_type -> scanoss.api.components.v2.ComponentsStatisticResponse
+	3,  // 24: scanoss.api.components.v2.Components.GetComponentStatus:output_type -> scanoss.api.components.v2.ComponentStatusResponse
+	4,  // 25: scanoss.api.components.v2.Components.GetComponentsStatus:output_type -> scanoss.api.components.v2.ComponentsStatusResponse
+	20, // [20:26] is the sub-list for method output_type
+	14, // [14:20] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_scanoss_api_components_v2_scanoss_components_proto_init() }

--- a/protobuf/scanoss/api/components/v2/scanoss-components.proto
+++ b/protobuf/scanoss/api/components/v2/scanoss-components.proto
@@ -192,23 +192,38 @@ message ComponentStatusResponse {
   
   // Component version status
   message VersionStatus {
-    // Specific version name  
-    string version = 1;  
-    // Development status of the requested version of this component classified automatically 
-    string status = 2;  
+    // Specific version name
+    string version = 1;
+    // Development status of the requested version of this component classified automatically
+    string status = 2;
     // Raw status reported by the registry for this version
     string repository_status = 3[json_name = "repository_status"];
     // Date that the component was indexed
     string indexed_date = 4 [json_name = "indexed_date"];
     // Date that the status was checked
     string status_change_date = 5 [json_name = "status_change_date"];
-    // States if something went wrong while searching for the version of this component version in the DB
-    optional string error_message = 6[json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 7  [json_name = "error_code"];
+
+    // Field 6 previously held `string error_message`; field 7 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were replaced
+    // by `info_message`/`info_code` below. These numbers and JSON names must
+    // never be reused, to avoid wire-type or semantic collisions with legacy
+    // clients still encoding them.
+    reserved 6, 7;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 8 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "NO_INFO":             No status information is available for the requested component.
+    //   - "INVALID_SEMVER":      The provided semantic version (SemVer) is invalid or malformed.
+    //   - "VERSION_NOT_FOUND":   The specific component version could not be found.
+    optional string info_code = 9 [json_name = "info_code"];
   }
   // Component status details (ignoring version)
   message ComponentStatus {
-    // Development status of the requested component classified automatically 
+    // Development status of the requested component classified automatically
     string status = 1;
     // Raw status reported by the registry for this component
     string repository_status = 2 [json_name = "repository_status"];
@@ -218,10 +233,24 @@ message ComponentStatusResponse {
     string last_indexed_date = 4 [json_name = "last_indexed_date"];
     // Date of the last detected change
     string status_change_date = 5 [json_name = "status_change_date"];
-    // States if something went wrong while searching for the version of this component in the DB
-    optional  string error_message = 6 [json_name = "error_message"];
-    optional common.v2.ErrorCode error_code = 7  [json_name = "error_code"];
-  
+
+    // Field 6 previously held `string error_message`; field 7 previously held
+    // `common.v2.ErrorCode error_code` (enum, varint-wire). Both were replaced
+    // by `info_message`/`info_code` below. These numbers and JSON names must
+    // never be reused, to avoid wire-type or semantic collisions with legacy
+    // clients still encoding them.
+    reserved 6, 7;
+    reserved "error_message", "error_code";
+
+    // Status message describing the outcome of processing this component.
+    optional string info_message = 8 [json_name = "info_message"];
+    // Status code identifying the outcome of processing this component.
+    //
+    // Possible values:
+    //   - "INVALID_PURL":        The provided Package URL (PURL) is invalid or malformed.
+    //   - "COMPONENT_NOT_FOUND": The requested component could not be found in the database.
+    //   - "NO_INFO":             No status information is available for the requested component.
+    optional string info_code = 9 [json_name = "info_code"];
   }
   // Information about the requested version. If no requirement is described, the latest version of the component is responded
   VersionStatus version_status = 4 [json_name = "version_status"];

--- a/protobuf/scanoss/api/components/v2/scanoss-components.swagger.json
+++ b/protobuf/scanoss/api/components/v2/scanoss-components.swagger.json
@@ -376,12 +376,13 @@
           "type": "string",
           "title": "Date of the last detected change"
         },
-        "error_message": {
+        "info_message": {
           "type": "string",
-          "title": "States if something went wrong while searching for the version of this component in the DB"
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"INVALID_PURL\":        The provided Package URL (PURL) is invalid or malformed.\n  - \"COMPONENT_NOT_FOUND\": The requested component could not be found in the database.\n  - \"NO_INFO\":             No status information is available for the requested component."
         }
       },
       "title": "Component status details (ignoring version)"
@@ -409,12 +410,13 @@
           "type": "string",
           "title": "Date that the status was checked"
         },
-        "error_message": {
+        "info_message": {
           "type": "string",
-          "title": "States if something went wrong while searching for the version of this component version in the DB"
+          "description": "Status message describing the outcome of processing this component."
         },
-        "error_code": {
-          "$ref": "#/definitions/v2ErrorCode"
+        "info_code": {
+          "type": "string",
+          "description": "Status code identifying the outcome of processing this component.\n\nPossible values:\n  - \"NO_INFO\":             No status information is available for the requested component.\n  - \"INVALID_SEMVER\":      The provided semantic version (SemVer) is invalid or malformed.\n  - \"VERSION_NOT_FOUND\":   The specific component version could not be found."
         }
       },
       "title": "Component version status"
@@ -839,19 +841,6 @@
         }
       },
       "description": "Echo Message Response."
-    },
-    "v2ErrorCode": {
-      "type": "string",
-      "enum": [
-        "INVALID_PURL",
-        "COMPONENT_NOT_FOUND",
-        "NO_INFO",
-        "INVALID_SEMVER",
-        "VERSION_NOT_FOUND",
-        "TOO_MANY_CONTRIBUTORS"
-      ],
-      "default": "INVALID_PURL",
-      "description": "Error code enum for component analysis operations.\nRepresents the various error conditions that can occur during component processing and validation.\n\n - INVALID_PURL: The provided Package URL (PURL) is invalid or malformed\n - COMPONENT_NOT_FOUND: The requested component could not be found in the database\n - NO_INFO: No information is available for the requested component\n - INVALID_SEMVER: The provided semantic version (SemVer) is invalid or malformed\n - VERSION_NOT_FOUND: Component version not found\n - TOO_MANY_CONTRIBUTORS: Too many contributors for a component. Used by Geoprovenance service"
     },
     "v2StatusCode": {
       "type": "string",


### PR DESCRIPTION
…massage/info_code in component responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `ComponentStatusResponse` now uses `info_message` and `info_code` as the definitive outcome fields. The previous `error_message` and `error_code` fields have been removed. Clients must migrate their implementations to use the new field names for both version and component status responses to continue receiving status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->