### PR TITLE
update hfh definition adding release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.43.0] - 2026-06-04
 ### Added
 - Added optional `release_date` field (ISO `YYYY-MM-DD` string) to `HFHResponse.Version` in the Scanning v2 service, exposing the per-version release date returned by Folder Hashing scans
 - Added optional `url_hash` field (string) to `HFHResponse.Version` in the Scanning v2 service, exposing the per-version URL hash returned by Folder Hashing scans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added optional `release_date` field (ISO `YYYY-MM-DD` string) to `HFHResponse.Version` in the Scanning v2 service, exposing the per-version release date returned by Folder Hashing scans
+- Added optional `url_hash` field (string) to `HFHResponse.Version` in the Scanning v2 service, exposing the per-version URL hash returned by Folder Hashing scans
 
 ## [0.42.0] - 2026-04-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added optional `release_date` field (ISO `YYYY-MM-DD` string) to `HFHResponse.Version` in the Scanning v2 service, exposing the per-version release date returned by Folder Hashing scans
 
 ## [0.42.0] - 2026-04-20
 ### Added

--- a/api/scanningv2/scanoss-scanning.pb.go
+++ b/api/scanningv2/scanoss-scanning.pb.go
@@ -295,7 +295,9 @@ type HFHResponse_Version struct {
 	// Component score (0-1)
 	Score float32 `protobuf:"fixed32,2,opt,name=score,proto3" json:"score,omitempty"`
 	// Licenses
-	Licenses      []*HFHResponse_Version_License `protobuf:"bytes,3,rep,name=licenses,proto3" json:"licenses,omitempty"`
+	Licenses []*HFHResponse_Version_License `protobuf:"bytes,3,rep,name=licenses,proto3" json:"licenses,omitempty"`
+	// Component version release date. Optional ISO date in YYYY-MM-DD format; may be empty when unknown or not provided by the upstream source.
+	ReleaseDate   string `protobuf:"bytes,4,opt,name=release_date,proto3" json:"release_date,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -349,6 +351,13 @@ func (x *HFHResponse_Version) GetLicenses() []*HFHResponse_Version_License {
 		return x.Licenses
 	}
 	return nil
+}
+
+func (x *HFHResponse_Version) GetReleaseDate() string {
+	if x != nil {
+		return x.ReleaseDate
+	}
+	return ""
 }
 
 // Matched component details
@@ -593,14 +602,15 @@ const file_scanoss_api_scanning_v2_scanoss_scanning_proto_rawDesc = "" +
 	"\x0flang_extensions\x18\x06 \x03(\v2@.scanoss.api.scanning.v2.HFHRequest.Children.LangExtensionsEntryR\x0flang_extensions\x1aA\n" +
 	"\x13LangExtensionsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xce\x05\n" +
+	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xf2\x05\n" +
 	"\vHFHResponse\x12E\n" +
 	"\aresults\x18\x01 \x03(\v2+.scanoss.api.scanning.v2.HFHResponse.ResultR\aresults\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\x82\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\xa6\x02\n" +
 	"\aVersion\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x14\n" +
 	"\x05score\x18\x02 \x01(\x02R\x05score\x12P\n" +
-	"\blicenses\x18\x03 \x03(\v24.scanoss.api.scanning.v2.HFHResponse.Version.LicenseR\blicenses\x1au\n" +
+	"\blicenses\x18\x03 \x03(\v24.scanoss.api.scanning.v2.HFHResponse.Version.LicenseR\blicenses\x12\"\n" +
+	"\frelease_date\x18\x04 \x01(\tR\frelease_date\x1au\n" +
 	"\aLicense\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aspdx_id\x18\x02 \x01(\tR\aspdx_id\x12*\n" +

--- a/api/scanningv2/scanoss-scanning.pb.go
+++ b/api/scanningv2/scanoss-scanning.pb.go
@@ -297,7 +297,9 @@ type HFHResponse_Version struct {
 	// Licenses
 	Licenses []*HFHResponse_Version_License `protobuf:"bytes,3,rep,name=licenses,proto3" json:"licenses,omitempty"`
 	// Component version release date. Optional ISO date in YYYY-MM-DD format; may be empty when unknown or not provided by the upstream source.
-	ReleaseDate   string `protobuf:"bytes,4,opt,name=release_date,proto3" json:"release_date,omitempty"`
+	ReleaseDate string `protobuf:"bytes,4,opt,name=release_date,proto3" json:"release_date,omitempty"`
+	// Hash of the URL associated with this component version. Optional; may be empty when not provided by the upstream source.
+	UrlHash       string `protobuf:"bytes,5,opt,name=url_hash,proto3" json:"url_hash,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -356,6 +358,13 @@ func (x *HFHResponse_Version) GetLicenses() []*HFHResponse_Version_License {
 func (x *HFHResponse_Version) GetReleaseDate() string {
 	if x != nil {
 		return x.ReleaseDate
+	}
+	return ""
+}
+
+func (x *HFHResponse_Version) GetUrlHash() string {
+	if x != nil {
+		return x.UrlHash
 	}
 	return ""
 }
@@ -602,15 +611,16 @@ const file_scanoss_api_scanning_v2_scanoss_scanning_proto_rawDesc = "" +
 	"\x0flang_extensions\x18\x06 \x03(\v2@.scanoss.api.scanning.v2.HFHRequest.Children.LangExtensionsEntryR\x0flang_extensions\x1aA\n" +
 	"\x13LangExtensionsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xf2\x05\n" +
+	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\x8e\x06\n" +
 	"\vHFHResponse\x12E\n" +
 	"\aresults\x18\x01 \x03(\v2+.scanoss.api.scanning.v2.HFHResponse.ResultR\aresults\x12=\n" +
-	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\xa6\x02\n" +
+	"\x06status\x18\x02 \x01(\v2%.scanoss.api.common.v2.StatusResponseR\x06status\x1a\xc2\x02\n" +
 	"\aVersion\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x14\n" +
 	"\x05score\x18\x02 \x01(\x02R\x05score\x12P\n" +
 	"\blicenses\x18\x03 \x03(\v24.scanoss.api.scanning.v2.HFHResponse.Version.LicenseR\blicenses\x12\"\n" +
-	"\frelease_date\x18\x04 \x01(\tR\frelease_date\x1au\n" +
+	"\frelease_date\x18\x04 \x01(\tR\frelease_date\x12\x1a\n" +
+	"\burl_hash\x18\x05 \x01(\tR\burl_hash\x1au\n" +
 	"\aLicense\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aspdx_id\x18\x02 \x01(\tR\aspdx_id\x12*\n" +

--- a/protobuf/scanoss/api/scanning/v2/scanoss-scanning.proto
+++ b/protobuf/scanoss/api/scanning/v2/scanoss-scanning.proto
@@ -143,6 +143,8 @@ message HFHResponse {
         float score = 2;
         // Licenses
         repeated License licenses = 3;
+        // Component version release date. Optional ISO date in YYYY-MM-DD format; may be empty when unknown or not provided by the upstream source.
+        string release_date = 4 [json_name = "release_date"];
     }
     // Matched component details
     message Component {

--- a/protobuf/scanoss/api/scanning/v2/scanoss-scanning.proto
+++ b/protobuf/scanoss/api/scanning/v2/scanoss-scanning.proto
@@ -145,6 +145,8 @@ message HFHResponse {
         repeated License licenses = 3;
         // Component version release date. Optional ISO date in YYYY-MM-DD format; may be empty when unknown or not provided by the upstream source.
         string release_date = 4 [json_name = "release_date"];
+        // Hash of the URL associated with this component version. Optional; may be empty when not provided by the upstream source.
+        string url_hash = 5 [json_name = "url_hash"];
     }
     // Matched component details
     message Component {

--- a/protobuf/scanoss/api/scanning/v2/scanoss-scanning.swagger.json
+++ b/protobuf/scanoss/api/scanning/v2/scanoss-scanning.swagger.json
@@ -222,6 +222,10 @@
         "release_date": {
           "type": "string",
           "description": "Component version release date. Optional ISO date in YYYY-MM-DD format; may be empty when unknown or not provided by the upstream source."
+        },
+        "url_hash": {
+          "type": "string",
+          "description": "Hash of the URL associated with this component version. Optional; may be empty when not provided by the upstream source."
         }
       },
       "title": "Component version details"

--- a/protobuf/scanoss/api/scanning/v2/scanoss-scanning.swagger.json
+++ b/protobuf/scanoss/api/scanning/v2/scanoss-scanning.swagger.json
@@ -218,6 +218,10 @@
             "$ref": "#/definitions/HFHResponseVersionLicense"
           },
           "title": "Licenses"
+        },
+        "release_date": {
+          "type": "string",
+          "description": "Component version release date. Optional ISO date in YYYY-MM-DD format; may be empty when unknown or not provided by the upstream source."
         }
       },
       "title": "Component version details"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `release_date` field to API responses, providing ISO-formatted dates (YYYY-MM-DD) for scan results when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->